### PR TITLE
(FM-7697) Make localhost work without inventory file

### DIFF
--- a/lib/solid_waffle/rake_tasks.rb
+++ b/lib/solid_waffle/rake_tasks.rb
@@ -219,13 +219,13 @@ namespace :waffle do
           ENV['TARGET_HOST'] = host
         end
       end
-      # add localhost separately
-      desc 'Run serverspec against localhost, USE WITH CAUTION, this action can be potentially dangerous.'
-      host = 'localhost'
-      RSpec::Core::RakeTask.new(host.to_sym) do |t|
-        t.pattern = 'spec/acceptance/**{,/*/**}/*_spec.rb'
-        ENV['TARGET_HOST'] = host
-      end
+    end
+    # add localhost separately
+    desc 'Run serverspec against localhost, USE WITH CAUTION, this action can be potentially dangerous.'
+    host = 'localhost'
+    RSpec::Core::RakeTask.new(host.to_sym) do |t|
+      t.pattern = 'spec/acceptance/**{,/*/**}/*_spec.rb'
+      ENV['TARGET_HOST'] = host
     end
   end
 end


### PR DESCRIPTION
The issue behind this bug is that the localhost rake task was setup only if the inventory file was present, moved it so it works again as intended.