### PR TITLE
Require bolt >= 0.21.4 and remove pry requirement

### DIFF
--- a/lib/puppet_litmus.rb
+++ b/lib/puppet_litmus.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'pry'
 require 'bolt_spec/run'
 
 # Helper methods for testing puppet content

--- a/puppet_litmus.gemspec
+++ b/puppet_litmus.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
     Providing a simple command line tool for puppet content creators, to enable simple and complex test deployments.
   EOF
   spec.summary = 'Providing a simple command line tool for puppet content creators, to enable simple and complex test deployments.'
-  spec.add_runtime_dependency 'bolt',  ['>= 0.20.0', '< 2.0.0']
+  spec.add_runtime_dependency 'bolt',  ['>= 0.21.4', '< 2.0.0']
 end


### PR DESCRIPTION
This bolt version refactored and introduced bolt_spec/run. Pry shouldn't be a requirement at runtime.

https://github.com/puppetlabs/puppet_litmus/issues/66 is still a problem with this.