### PR TITLE
(bugfix) - Fix provision_from_metadata

### DIFF
--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -54,7 +54,7 @@ namespace :litmus do
           raise "the provision module was not found in #{config_data['modulepath']}, please amend the .fixtures.yml file" unless File.directory?(File.join(config_data['modulepath'], 'provision'))
 
           params = { 'action' => 'provision', 'platform' => os_and_version, 'inventory' => Dir.pwd }
-          results = run_task("litmus_provision::#{args[:provisioner]}", 'localhost', params, config: config_data, inventory: nil)
+          results = run_task("provision::#{args[:provisioner]}", 'localhost', params, config: config_data, inventory: nil)
           results.each do |result|
             if result['status'] != 'success'
               puts "Failed on #{result['node']}\n#{result}"


### PR DESCRIPTION
Currently when calling ` bundle exec rake 'litmus:provision_from_metadata'` the following failure is returned. Updating litmus_provision to provision resolves this.

```
➜  puppetlabs-motd git:(litmus_paulas_branch) ✗ bundle exec rake 'litmus:provision_from_metadata'
redhat-5-x86_64
rake aborted!
Bolt::PAL::PALError: Could not find a task named "litmus_provision::". For a list of available tasks, run "bolt task show"
````