### PR TITLE
(FM-7579) - Limiting lower range of bolt dependency to 1.13.1

### DIFF
--- a/puppet_litmus.gemspec
+++ b/puppet_litmus.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
     Providing a simple command line tool for puppet content creators, to enable simple and complex test deployments.
   EOF
   spec.summary = 'Providing a simple command line tool for puppet content creators, to enable simple and complex test deployments.'
-  spec.add_runtime_dependency 'bolt',  ['>= 0.21.4', '< 2.0.0']
+  spec.add_runtime_dependency 'bolt',  ['>= 1.13.1', '< 2.0.0']
 end


### PR DESCRIPTION
Versions of bolt lower than 1.13.1 cause dependency issues which result in the bundle completing. Limiting the lower version requirement to 1.13.1. This is related to cri and pdk dependencies.