### PR TITLE
(FM-7870) - Return with exit code 1 when tests fail

### DIFF
--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -222,10 +222,10 @@ namespace :litmus do
         # if any result is nonzero, there were test failures
         failures = false
         results.each do |result|
-          failures = true unless result.last.to_i.zero?
+          failures = true unless result.last.exitstatus.zero?
           puts result
         end
-        1 if failures
+        exit 1 if failures
       end
 
       hosts.each do |host|


### PR DESCRIPTION
This test has been tested with a local setup and I can confirm tests that should fail in travis now fail as the exit code is returned instead of returning 0 every time.

<img width="1080" alt="Screen Shot 2019-03-20 at 5 10 03 PM" src="https://user-images.githubusercontent.com/20774767/54704642-12108a80-4b33-11e9-8b68-a4c749c9d4b3.png">
