### PR TITLE
Added require for tempfile

### DIFF
--- a/lib/puppet_litmus/serverspec.rb
+++ b/lib/puppet_litmus/serverspec.rb
@@ -61,6 +61,8 @@ module PuppetLitmus::Serverspec
   # @param manifest [String] puppet manifest code.
   # @return [String] The path to the location of the manifest.
   def create_manifest_file(manifest)
+    require 'tempfile'
+
     target_node_name = ENV['TARGET_HOST']
     manifest_file = Tempfile.new(['manifest_', '.pp'])
     manifest_file.write(manifest)


### PR DESCRIPTION
Under normal circumstances `tempfile` has not been required at the point where we call out to it meaning that people can get this error:

```
NameError:
  uninitialized constant PuppetLitmus::Serverspec::Tempfile

# ./.bundle/gems/ruby/2.3.0/gems/puppet_litmus-0.1.1/lib/puppet_litmus/serverspec.rb:46:in `create_manifest_file'
# ./.bundle/gems/ruby/2.3.0/gems/puppet_litmus-0.1.1/lib/puppet_litmus/serverspec.rb:6:in `idempotent_apply'
# ./spec/acceptance/safe_include_spec.rb:14:in `block (2 levels) in <top (required)>'
# ./spec/acceptance/safe_include_spec.rb:4:in `block in <top (required)>'
# ./spec/acceptance/safe_include_spec.rb:3:in `<top (required)>'
```

This fixes that