### PR TITLE
(FM-8178) Make params passable using provision.yaml

### DIFF
--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -107,6 +107,8 @@ namespace :litmus do
   task :provision_list, [:key] do |_task, args|
     provision_hash = YAML.load_file('./provision.yaml')
     provisioner = provision_hash[args[:key]]['provisioner']
+    # Splat the params into environment variables to pass to the provision task but only in this runspace
+    provision_hash[args[:key]]['params'].each { |key, value| ENV["LITMUS_#{key.upcase}"] = value }
     failed_image_message = ''
     provision_hash[args[:key]]['images'].each do |image|
       # this is the only way to capture the stdout from the rake task, it will affect pry


### PR DESCRIPTION
Prior to this commit the only way to pass additional provisioning params
to a provisioning task was via environment variables. This commit adds
an optional params hash to the provision.yaml definition, enabling a
user to pass an arbitrary set of keys to the provisioner.

These are transformed into environment variables as `LITMUS_param` where
the `param` is upcased. This will enable users of the vagrant provisioner
on windows to pass SMB username and passwords via the provision file
instead of typing them into the terminal.

The environment variables created during the run do not persist outside
of the ruby runspace.