### PR TITLE
(FM-8296) Ensure serverspec helpers emit correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /coverage
 /doc/
 /vendor/gems/
+/Gemfile.local

--- a/Gemfile
+++ b/Gemfile
@@ -18,3 +18,16 @@ group :development do
   gem 'pry'
   gem 'yard'
 end
+
+# Evaluate Gemfile.local and ~/.gemfile if they exist
+extra_gemfiles = [
+  "#{__FILE__}.local",
+  File.join(Dir.home, '.gemfile'),
+]
+
+extra_gemfiles.each do |gemfile|
+  if File.file?(gemfile) && File.readable?(gemfile)
+    eval(File.read(gemfile), binding)
+  end
+end
+# vim: syntax=ruby

--- a/spec/lib/puppet_litmus/serverspec_spec.rb
+++ b/spec/lib/puppet_litmus/serverspec_spec.rb
@@ -54,28 +54,46 @@ RSpec.describe PuppetLitmus::Serverspec do
   describe '.bolt_upload_file' do
     let(:local) { '/tmp' }
     let(:remote) { '/remote_tmp' }
-    let(:result) { ['status' => 'success', 'result' => { 'exit_code' => 0, 'stdout' => nil, 'stderr' => nil }] }
+    # Ignore rubocop because these hashes are representative of output from an external method and editing them leads to test failures.
+    # rubocop:disable SpaceInsideHashLiteralBraces, SpaceInsideBlockBraces, SpaceAroundOperators, LineLength, SpaceAfterComma
+    let(:result_success) {[{'node'=>'some.host','target'=>'some.host','action'=>'upload','object'=>'C:\foo\bar.ps1','status'=>'success','result'=>{'_output'=>'Uploaded \'C:\foo\bar.ps1\' to \'some.host:C:\bar\''}}]}
+    let(:result_failure) {[{'node'=>'some.host','target'=>'some.host','action'=>nil,'object'=>nil,'status'=>'failure','result'=>{'_error'=>{'kind'=>'puppetlabs.tasks/task_file_error','msg'=>'No such file or directory @ rb_sysopen - /nonexistant/file/path','details'=>{},'issue_code'=>'WRITE_ERROR'}}}]}
+    # rubocop:enable SpaceInsideHashLiteralBraces, SpaceInsideBlockBraces, SpaceAroundOperators, LineLength, SpaceAfterComma
     let(:inventory_hash) { Hash.new(0) }
 
     it 'responds to run_shell' do
       expect(dummy_class).to respond_to(:bolt_upload_file).with(2..3).arguments
     end
 
-    context 'when running against remote host' do
+    context 'when upload returns success' do
       it 'does upload_file against remote host without error' do
         stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
-        expect(dummy_class).to receive(:upload_file).with(local, remote, 'some.host', options: {}, config: nil, inventory: inventory_hash).and_return(result)
+        expect(dummy_class).to receive(:upload_file).with(local, remote, 'some.host', options: {}, config: nil, inventory: inventory_hash).and_return(result_success)
+        expect { dummy_class.bolt_upload_file(local, remote) }.not_to raise_error
+      end
+      it 'does upload_file against localhost without error' do
+        stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'localhost'))
+        expect(dummy_class).not_to receive(:inventory_hash_from_inventory_file)
+        expect(dummy_class).to receive(:upload_file).with(local, remote, 'localhost', options: {}, config: nil, inventory: nil).and_return(result_success)
         expect { dummy_class.bolt_upload_file(local, remote) }.not_to raise_error
       end
     end
 
-    context 'when running against remote host' do
-      it 'does upload_file against localhost without error' do
-        stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'localhost'))
-        expect(dummy_class).not_to receive(:inventory_hash_from_inventory_file)
-        expect(dummy_class).to receive(:upload_file).with(local, remote, 'localhost', options: {}, config: nil, inventory: nil).and_return(result)
-        expect { dummy_class.bolt_upload_file(local, remote) }.not_to raise_error
+    context 'when upload returns failure' do
+      it 'does upload_file gives runtime error for failure' do
+        stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
+        expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
+        expect(dummy_class).to receive(:upload_file).with(local, remote, 'some.host', options: {}, config: nil, inventory: inventory_hash).and_return(result_failure)
+        expect { dummy_class.bolt_upload_file(local, remote) }.to raise_error(RuntimeError, %r{upload file failed})
+      end
+      it 'returns the exit code and error message when expecting failure' do
+        stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
+        expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
+        expect(dummy_class).to receive(:upload_file).with(local, remote, 'some.host', options: {}, config: nil, inventory: inventory_hash).and_return(result_failure)
+        method_result = dummy_class.bolt_upload_file(local, remote, expect_failures: true)
+        expect(method_result.exit_code).to be(255)
+        expect(method_result.stderr).to be('No such file or directory @ rb_sysopen - /nonexistant/file/path')
       end
     end
   end
@@ -121,8 +139,12 @@ RSpec.describe PuppetLitmus::Serverspec do
     let(:task_name) { 'testtask' }
     let(:params) { { 'action' => 'install', 'name' => 'foo' } }
     let(:config_data) { { 'modulepath' => File.join(Dir.pwd, 'spec', 'fixtures', 'modules') } }
-    let(:result_success) { ['status' => 'success', 'result' => { 'exit_code' => 0, 'stdout' => nil, 'stderr' => nil, 'result' => nil }] }
-    let(:result_failure) { ['status' => 'failure', 'result' => { 'exit_code' => 255, 'stdout' => 'failure', 'stderr' => 'failure', 'result' => nil }] }
+    # Ignore rubocop because these hashes are representative of output from an external method and editing them leads to test failures.
+    # rubocop:disable SpaceInsideHashLiteralBraces, SpaceBeforeBlockBraces, SpaceInsideBlockBraces, SpaceAroundOperators, LineLength, SpaceAfterComma
+    let(:result_unstructured_task_success){ [{'node'=>'some.host','target'=>'some.host','action'=>'task','object'=>'testtask::unstructured','status'=>'success','result'=>{'_output'=>'SUCCESS!'}}]}
+    let(:result_structured_task_success){ [{'node'=>'some.host','target'=>'some.host','action'=>'task','object'=>'testtask::structured','status'=>'success','result'=>{'key1'=>'foo','key2'=>'bar'}}]}
+    let(:result_failure) {[{'node'=>'some.host','target'=>'some.host','action'=>'task','object'=>'testtask::unstructured','status'=>'failure','result'=>{'_error'=>{'msg'=>'FAILURE!','kind'=>'puppetlabs.tasks/task-error','details'=>{'exitcode'=>123}}}}]}
+    # rubocop:enable SpaceInsideHashLiteralBraces, SpaceBeforeBlockBraces, SpaceInsideBlockBraces, SpaceAroundOperators, LineLength, SpaceAfterComma
     let(:inventory_hash) { Hash.new(0) }
 
     it 'responds to bolt_run_task' do
@@ -133,8 +155,24 @@ RSpec.describe PuppetLitmus::Serverspec do
       it 'does bolt_task_run gives no runtime error for success' do
         stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
-        expect(dummy_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_success)
+        expect(dummy_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_unstructured_task_success)
         expect { dummy_class.run_bolt_task(task_name, params, opts: {}) }.not_to raise_error
+      end
+      it 'returns stdout for unstructured-data tasks' do
+        stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
+        expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
+        expect(dummy_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_unstructured_task_success)
+        method_result = dummy_class.run_bolt_task(task_name, params, opts: {})
+        expect(method_result.stdout).to eq('SUCCESS!')
+      end
+      it 'returns structured output for structured-data tasks' do
+        stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
+        expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
+        expect(dummy_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_structured_task_success)
+        method_result = dummy_class.run_bolt_task(task_name, params, opts: {})
+        expect(method_result.stdout).to eq(nil)
+        expect(method_result.result['key1']).to eq('foo')
+        expect(method_result.result['key2']).to eq('bar')
       end
     end
 
@@ -144,6 +182,14 @@ RSpec.describe PuppetLitmus::Serverspec do
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
         expect(dummy_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_failure)
         expect { dummy_class.run_bolt_task(task_name, params, opts: {}) }.to raise_error(RuntimeError, %r{task failed})
+      end
+      it 'returns the exit code and error message when expecting failure' do
+        stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
+        expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
+        expect(dummy_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_failure)
+        method_result = dummy_class.run_bolt_task(task_name, params, expect_failures: true)
+        expect(method_result.exit_code).to be(123)
+        expect(method_result.stderr).to be('FAILURE!')
       end
     end
   end

--- a/spec/lib/puppet_litmus/serverspec_spec.rb
+++ b/spec/lib/puppet_litmus/serverspec_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe PuppetLitmus::Serverspec do
 
     context 'when running against localhost and no inventory.yaml file' do
       it 'does run_shell against localhost without error' do
-        allow(ENV).to receive(:[]).with('TARGET_HOST').and_return('localhost')
+        stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'localhost'))
         expect(dummy_class).to receive(:run_command).with(command_to_run, 'localhost', config: nil, inventory: nil).and_return(result)
         expect { dummy_class.run_shell(command_to_run) }.not_to raise_error
       end
@@ -43,7 +43,7 @@ RSpec.describe PuppetLitmus::Serverspec do
 
     context 'when running against remote host' do
       it 'does run_shell against remote host without error' do
-        allow(ENV).to receive(:[]).with('TARGET_HOST').and_return('some.host')
+        stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
         expect(dummy_class).to receive(:run_command).with(command_to_run, 'some.host', config: nil, inventory: inventory_hash).and_return(result)
         expect { dummy_class.run_shell(command_to_run) }.not_to raise_error
@@ -63,7 +63,7 @@ RSpec.describe PuppetLitmus::Serverspec do
 
     context 'when running against remote host' do
       it 'does upload_file against remote host without error' do
-        allow(ENV).to receive(:[]).with('TARGET_HOST').and_return('some.host')
+        stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
         expect(dummy_class).to receive(:upload_file).with(local, remote, 'some.host', options: {}, config: nil, inventory: inventory_hash).and_return(result)
         expect { dummy_class.bolt_upload_file(local, remote) }.not_to raise_error
@@ -72,7 +72,7 @@ RSpec.describe PuppetLitmus::Serverspec do
 
     context 'when running against remote host' do
       it 'does upload_file against localhost without error' do
-        allow(ENV).to receive(:[]).with('TARGET_HOST').and_return('localhost')
+        stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'localhost'))
         expect(dummy_class).not_to receive(:inventory_hash_from_inventory_file)
         expect(dummy_class).to receive(:upload_file).with(local, remote, 'localhost', options: {}, config: nil, inventory: nil).and_return(result)
         expect { dummy_class.bolt_upload_file(local, remote) }.not_to raise_error
@@ -91,7 +91,7 @@ RSpec.describe PuppetLitmus::Serverspec do
 
     context 'when running against localhost and no inventory.yaml file' do
       it 'does bolt_run_script against localhost without error' do
-        allow(ENV).to receive(:[]).with('TARGET_HOST').and_return('localhost')
+        stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'localhost'))
         expect(dummy_class).not_to receive(:inventory_hash_from_inventory_file)
         expect(dummy_class).to receive(:run_script).with(script, 'localhost', [], options: {}, config: nil, inventory: nil).and_return(result)
         expect { dummy_class.bolt_run_script(script) }.not_to raise_error
@@ -100,7 +100,7 @@ RSpec.describe PuppetLitmus::Serverspec do
 
     context 'when running against remote host' do
       it 'does bolt_run_script against remote host without error' do
-        allow(ENV).to receive(:[]).with('TARGET_HOST').and_return('some.host')
+        stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file)
         expect(dummy_class).to receive(:run_script).with(script, 'some.host', [], options: {}, config: nil, inventory: nil).and_return(result)
         expect { dummy_class.bolt_run_script(script) }.not_to raise_error
@@ -109,7 +109,7 @@ RSpec.describe PuppetLitmus::Serverspec do
 
     context 'when running with arguments' do
       it 'does bolt_run_script with arguments without error' do
-        allow(ENV).to receive(:[]).with('TARGET_HOST').and_return('localhost')
+        stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'localhost'))
         expect(dummy_class).not_to receive(:inventory_hash_from_inventory_file)
         expect(dummy_class).to receive(:run_script).with(script, 'localhost', ['doot'], options: {}, config: nil, inventory: nil).and_return(result)
         expect { dummy_class.bolt_run_script(script, arguments: ['doot']) }.not_to raise_error
@@ -131,7 +131,7 @@ RSpec.describe PuppetLitmus::Serverspec do
 
     context 'when bolt returns success' do
       it 'does bolt_task_run gives no runtime error for success' do
-        allow(ENV).to receive(:[]).with('TARGET_HOST').and_return('some.host')
+        stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
         expect(dummy_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_success)
         expect { dummy_class.run_bolt_task(task_name, params, opts: {}) }.not_to raise_error
@@ -140,7 +140,7 @@ RSpec.describe PuppetLitmus::Serverspec do
 
     context 'when bolt returns failure' do
       it 'does bolt_task_run gives runtime error for failure' do
-        allow(ENV).to receive(:[]).with('TARGET_HOST').and_return('some.host')
+        stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
         expect(dummy_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_failure)
         expect { dummy_class.run_bolt_task(task_name, params, opts: {}) }.to raise_error(RuntimeError, %r{task failed})


### PR DESCRIPTION
Prior to this commit the `run_bolt_task` and `bolt_upload_file` methods
did not correctly emit stdout and stderr - `run_bolt_task` also swallowed
the exit codes of a run.

This commit updates both methods to correctly capture and emit the stdout
and stderr streams and ensures that a specific exit code for a task is
captured instead of being overwritten to `255`.

The reason for these updates is that the `run_task` and `upload_file`
methods leveraged by `run_bolt_task` and `bolt_upload_file` respectively
do not return the same structured results as `run_command` and
`run script` - namely, it does not return the `exit_code`, `stderr`, and
`stdout` key-value pairs in the `result` hash.

Instead the output, exit code, and error must be extricated from the
object to be passed along.