### PR TITLE
(feat) Add option to run acceptance in serial

### DIFF
--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -426,6 +426,20 @@ namespace :litmus do
         exit 1 if failure_list.any?
       end
 
+      # Run acceptance tests against all machines in the inventory file in serial.
+      desc 'Run tests in serial against all machines in the inventory file'
+      task :serial do
+        # Iterate over all of the acceptance test tasks and invoke them;
+        # We can rely on them always being in the format `litmus:acceptance:host_name:port`
+        # The host_name might be localhost or an IP or a DNS-resolvable node.
+        prefix = 'litmus:acceptance:'
+        tasks = Rake::Task.tasks.select { |task| task.name =~ %r{^#{prefix}.+:\d+$} }
+        tasks.each do |task|
+          puts "Running acceptance tests against #{task.name[prefix.length..-1]}"
+          task.invoke
+        end
+      end
+
       targets.each do |target|
         desc "Run serverspec against #{target}"
         RSpec::Core::RakeTask.new(target.to_sym) do |t|
@@ -434,6 +448,7 @@ namespace :litmus do
         end
       end
     end
+
     # add localhost separately
     desc 'Run serverspec against localhost, USE WITH CAUTION, this action can be potentially dangerous.'
     host = 'localhost'


### PR DESCRIPTION
This commit adds the `litmus:acceptance:serial` task which is a meta task
that calls the `litmus:acceptance:host_name:port` tasks one after another.

This allows for execution of tests which share dependencies, like the bolt
inventory file, and cannot run in parallel because of that.