### PR TITLE
(FM-8477) Add paramter to pass hiera config to apply calls

### DIFF
--- a/lib/puppet_litmus/serverspec.rb
+++ b/lib/puppet_litmus/serverspec.rb
@@ -27,6 +27,7 @@ module PuppetLitmus::Serverspec
   #  :catch_changes [Boolean] exit status of 1 if there were changes.  
   #  :expect_failures [Boolean] doesnt return an exit code of non-zero if the apply failed.  
   #  :manifest_file_location [Path] The place on the target system.  
+  #  :hiera_config [Path] The path to the hiera.yaml configuration on the runner.
   #  :prefix_command [String] prefixes the puppet apply command; eg "export LANGUAGE='ja'".  
   #  :debug [Boolean] run puppet apply with the debug flag.  
   #  :noop [Boolean] run puppet apply with the noop flag.  
@@ -46,6 +47,7 @@ module PuppetLitmus::Serverspec
                      end
     command_to_run = "#{opts[:prefix_command]} puppet apply #{manifest_file_location}"
     command_to_run += " --modulepath #{Dir.pwd}/spec/fixtures/modules" if target_node_name.nil? || target_node_name == 'localhost'
+    command_to_run += " --hiera_config='#{opts[:hiera_config]}'" unless opts[:hiera_config].nil?
     command_to_run += ' --detailed-exitcodes' if !opts[:catch_changes].nil? && (opts[:catch_changes] == true)
     command_to_run += ' --debug' if !opts[:debug].nil? && (opts[:debug] == true)
     command_to_run += ' --noop' if !opts[:noop].nil? && (opts[:noop] == true)

--- a/spec/lib/puppet_litmus/serverspec_spec.rb
+++ b/spec/lib/puppet_litmus/serverspec_spec.rb
@@ -22,6 +22,20 @@ RSpec.describe PuppetLitmus::Serverspec do
     end
   end
 
+  describe '.apply_manifest' do
+    context 'when specifying a hiera config' do
+      let(:manifest) { "include '::doot'" }
+      let(:result) { ['result' => { 'exit_code' => 0, 'stdout' => nil, 'stderr' => nil }] }
+      let(:command) { " puppet apply /bla.pp --modulepath #{Dir.pwd}/spec/fixtures/modules --hiera_config='/hiera.yaml'" }
+
+      it 'passes the --hiera_config flag if the :hiera_config opt is specified' do
+        expect(dummy_class).to receive(:create_manifest_file).with(manifest).and_return('/bla.pp')
+        expect(dummy_class).to receive(:run_command).with(command, nil, config: nil, inventory: nil).and_return(result)
+        dummy_class.apply_manifest(manifest, hiera_config: '/hiera.yaml')
+      end
+    end
+  end
+
   describe '.run_shell' do
     let(:command_to_run) { "puts 'doot'" }
     let(:result) { ['result' => { 'exit_code' => 0, 'stdout' => nil, 'stderr' => nil }] }


### PR DESCRIPTION
Prior to this commit it was not possible to pass hiera data to an apply call
during a litmus run. This commit adds the option to the apply_manifest method.