### PR TITLE
(FM-8488) Correct param loading as env vars in provision_list

### DIFF
--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -108,7 +108,7 @@ namespace :litmus do
     provision_hash = YAML.load_file('./provision.yaml')
     provisioner = provision_hash[args[:key]]['provisioner']
     # Splat the params into environment variables to pass to the provision task but only in this runspace
-    provision_hash[args[:key]]['params']&.each { |key, value| ENV["LITMUS_#{key.upcase}"] = value }
+    provision_hash[args[:key]]['params']&.each { |key, value| ENV[key.upcase] = value.to_s }
     failed_image_message = ''
     provision_hash[args[:key]]['images'].each do |image|
       # this is the only way to capture the stdout from the rake task, it will affect pry


### PR DESCRIPTION
Prior to this commit the parameters loaded during provision_list
would be loaded as environment variables with LITMUS_ prepended.

This has been altered such that it does not alter the name of the
parameter except by upcasing for convention.