### PR TITLE
(FM-8342) Handle mocking of localhost

### DIFF
--- a/lib/puppet_litmus/inventory_manipulation.rb
+++ b/lib/puppet_litmus/inventory_manipulation.rb
@@ -18,6 +18,25 @@ module PuppetLitmus::InventoryManipulation
     inventory_hash
   end
 
+  # Provide a default hash for executing against localhost
+  #
+  # @return [Hash] inventory.yaml hash containing only an entry for localhost
+  def localhost_inventory_hash
+    {
+      'groups' => [
+        {
+          'name' => 'local',
+          'nodes' => [
+            {
+              'name' => 'litmus_localhost',
+              'config' => { 'transport' => 'local' },
+            },
+          ],
+        },
+      ],
+    }
+  end
+
   # Finds targets to perform operations on from an inventory hash.
   #
   # @param inventory_hash [Hash] hash of the inventory.yaml file
@@ -49,6 +68,15 @@ module PuppetLitmus::InventoryManipulation
       end
     end
     exists
+  end
+
+  # Determines if a node_name exists in the inventory_hash.
+  #
+  # @param inventory_hash [Hash] hash of the inventory.yaml file
+  # @param node_name [String] node to locate in the group
+  # @return [Boolean] true if node_name exists in the inventory_hash.
+  def target_in_inventory?(inventory_hash, node_name)
+    find_targets(inventory_hash, nil).include?(node_name)
   end
 
   # Finds a config hash in the inventory hash by searching for a node name.

--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -325,6 +325,8 @@ namespace :litmus do
 
     bad_results = []
     targets.each do |node_name|
+      next if node_name == 'litmus_localhost'
+
       # how do we know what provisioner to use
       node_facts = facts_from_node(inventory_hash, node_name)
       next unless %w[abs docker docker_exp vagrant vmpooler].include?(node_facts['provisioner'])
@@ -446,6 +448,8 @@ namespace :litmus do
 
       targets.each do |target|
         desc "Run serverspec against #{target}"
+        next if target == 'litmus_localhost'
+
         RSpec::Core::RakeTask.new(target.to_sym) do |t|
           t.pattern = 'spec/acceptance/**{,/*/**}/*_spec.rb'
           ENV['TARGET_HOST'] = target

--- a/spec/lib/puppet_litmus/serverspec_spec.rb
+++ b/spec/lib/puppet_litmus/serverspec_spec.rb
@@ -25,12 +25,16 @@ RSpec.describe PuppetLitmus::Serverspec do
   describe '.apply_manifest' do
     context 'when specifying a hiera config' do
       let(:manifest) { "include '::doot'" }
+      let(:localhost_inventory_hash) { { 'groups' => [{ 'name' => 'local', 'nodes' => [{ 'name' => 'litmus_localhost', 'config' => { 'transport' => 'local' } }] }] } }
       let(:result) { ['result' => { 'exit_code' => 0, 'stdout' => nil, 'stderr' => nil }] }
       let(:command) { " puppet apply /bla.pp --detailed-exitcodes --modulepath #{Dir.pwd}/spec/fixtures/modules --hiera_config='/hiera.yaml'" }
 
       it 'passes the --hiera_config flag if the :hiera_config opt is specified' do
+        expect(File).to receive(:exist?).with('inventory.yaml').and_return(false)
+        expect(dummy_class).to receive(:localhost_inventory_hash).and_return(localhost_inventory_hash)
+        expect(dummy_class).to receive(:target_in_inventory?).and_return(true)
         expect(dummy_class).to receive(:create_manifest_file).with(manifest).and_return('/bla.pp')
-        expect(dummy_class).to receive(:run_command).with(command, nil, config: nil, inventory: nil).and_return(result)
+        expect(dummy_class).to receive(:run_command).with(command, 'litmus_localhost', config: nil, inventory: localhost_inventory_hash).and_return(result)
         dummy_class.apply_manifest(manifest, hiera_config: '/hiera.yaml')
       end
     end
@@ -39,7 +43,8 @@ RSpec.describe PuppetLitmus::Serverspec do
   describe '.run_shell' do
     let(:command_to_run) { "puts 'doot'" }
     let(:result) { ['result' => { 'exit_code' => 0, 'stdout' => nil, 'stderr' => nil }] }
-    let(:inventory_hash) { Hash.new(0) }
+    let(:inventory_hash) { { 'groups' => [{ 'name' => 'ssh_nodes', 'nodes' => [{ 'name' => 'some.host' }] }] } }
+    let(:localhost_inventory_hash) { { 'groups' => [{ 'name' => 'local', 'nodes' => [{ 'name' => 'litmus_localhost', 'config' => { 'transport' => 'local' } }] }] } }
 
     it 'responds to run_shell' do
       expect(dummy_class).to respond_to(:run_shell).with(1..2).arguments
@@ -48,7 +53,10 @@ RSpec.describe PuppetLitmus::Serverspec do
     context 'when running against localhost and no inventory.yaml file' do
       it 'does run_shell against localhost without error' do
         stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'localhost'))
-        expect(dummy_class).to receive(:run_command).with(command_to_run, 'localhost', config: nil, inventory: nil).and_return(result)
+        expect(File).to receive(:exist?).with('inventory.yaml').and_return(false)
+        expect(dummy_class).to receive(:localhost_inventory_hash).and_return(localhost_inventory_hash)
+        expect(dummy_class).to receive(:target_in_inventory?).and_return(true)
+        expect(dummy_class).to receive(:run_command).with(command_to_run, 'litmus_localhost', config: nil, inventory: localhost_inventory_hash).and_return(result)
         expect { dummy_class.run_shell(command_to_run) }.not_to raise_error
       end
     end
@@ -56,7 +64,9 @@ RSpec.describe PuppetLitmus::Serverspec do
     context 'when running against remote host' do
       it 'does run_shell against remote host without error' do
         stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
+        expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
+        expect(dummy_class).to receive(:target_in_inventory?).and_return(true)
         expect(dummy_class).to receive(:run_command).with(command_to_run, 'some.host', config: nil, inventory: inventory_hash).and_return(result)
         expect { dummy_class.run_shell(command_to_run) }.not_to raise_error
       end
@@ -71,7 +81,8 @@ RSpec.describe PuppetLitmus::Serverspec do
     let(:result_success) {[{'node'=>'some.host','target'=>'some.host','action'=>'upload','object'=>'C:\foo\bar.ps1','status'=>'success','result'=>{'_output'=>'Uploaded \'C:\foo\bar.ps1\' to \'some.host:C:\bar\''}}]}
     let(:result_failure) {[{'node'=>'some.host','target'=>'some.host','action'=>nil,'object'=>nil,'status'=>'failure','result'=>{'_error'=>{'kind'=>'puppetlabs.tasks/task_file_error','msg'=>'No such file or directory @ rb_sysopen - /nonexistant/file/path','details'=>{},'issue_code'=>'WRITE_ERROR'}}}]}
     # rubocop:enable SpaceInsideHashLiteralBraces, SpaceInsideBlockBraces, SpaceAroundOperators, LineLength, SpaceAfterComma
-    let(:inventory_hash) { Hash.new(0) }
+    let(:inventory_hash) { { 'groups' => [{ 'name' => 'local', 'nodes' => [{ 'name' => 'some.host', 'config' => { 'transport' => 'local' } }] }] } }
+    let(:localhost_inventory_hash) { { 'groups' => [{ 'name' => 'local', 'nodes' => [{ 'name' => 'litmus_localhost', 'config' => { 'transport' => 'local' } }] }] } }
 
     it 'responds to run_shell' do
       expect(dummy_class).to respond_to(:bolt_upload_file).with(2..3).arguments
@@ -80,14 +91,19 @@ RSpec.describe PuppetLitmus::Serverspec do
     context 'when upload returns success' do
       it 'does upload_file against remote host without error' do
         stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
+        expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
+        expect(dummy_class).to receive(:target_in_inventory?).and_return(true)
         expect(dummy_class).to receive(:upload_file).with(local, remote, 'some.host', options: {}, config: nil, inventory: inventory_hash).and_return(result_success)
         expect { dummy_class.bolt_upload_file(local, remote) }.not_to raise_error
       end
       it 'does upload_file against localhost without error' do
         stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'localhost'))
+        expect(File).to receive(:exist?).with('inventory.yaml').and_return(false)
+        expect(dummy_class).to receive(:localhost_inventory_hash).and_return(localhost_inventory_hash)
         expect(dummy_class).not_to receive(:inventory_hash_from_inventory_file)
-        expect(dummy_class).to receive(:upload_file).with(local, remote, 'localhost', options: {}, config: nil, inventory: nil).and_return(result_success)
+        expect(dummy_class).to receive(:target_in_inventory?).and_return(true)
+        expect(dummy_class).to receive(:upload_file).with(local, remote, 'litmus_localhost', options: {}, config: nil, inventory: localhost_inventory_hash).and_return(result_success)
         expect { dummy_class.bolt_upload_file(local, remote) }.not_to raise_error
       end
     end
@@ -95,13 +111,17 @@ RSpec.describe PuppetLitmus::Serverspec do
     context 'when upload returns failure' do
       it 'does upload_file gives runtime error for failure' do
         stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
+        expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
+        expect(dummy_class).to receive(:target_in_inventory?).and_return(true)
         expect(dummy_class).to receive(:upload_file).with(local, remote, 'some.host', options: {}, config: nil, inventory: inventory_hash).and_return(result_failure)
         expect { dummy_class.bolt_upload_file(local, remote) }.to raise_error(RuntimeError, %r{upload file failed})
       end
       it 'returns the exit code and error message when expecting failure' do
         stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
+        expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
+        expect(dummy_class).to receive(:target_in_inventory?).and_return(true)
         expect(dummy_class).to receive(:upload_file).with(local, remote, 'some.host', options: {}, config: nil, inventory: inventory_hash).and_return(result_failure)
         method_result = dummy_class.bolt_upload_file(local, remote, expect_failures: true)
         expect(method_result.exit_code).to be(255)
@@ -113,7 +133,8 @@ RSpec.describe PuppetLitmus::Serverspec do
   describe '.bolt_run_script' do
     let(:script) { '/tmp/script.sh' }
     let(:result) { ['result' => { 'exit_code' => 0, 'stdout' => nil, 'stderr' => nil }] }
-    let(:inventory_hash) { Hash.new(0) }
+    let(:inventory_hash) { { 'groups' => [{ 'name' => 'local', 'nodes' => [{ 'name' => 'some.host', 'config' => { 'transport' => 'local' } }] }] } }
+    let(:localhost_inventory_hash) { { 'groups' => [{ 'name' => 'local', 'nodes' => [{ 'name' => 'litmus_localhost', 'config' => { 'transport' => 'local' } }] }] } }
 
     it 'responds to bolt_run_script' do
       expect(dummy_class).to respond_to(:bolt_run_script).with(1..2).arguments
@@ -122,8 +143,11 @@ RSpec.describe PuppetLitmus::Serverspec do
     context 'when running against localhost and no inventory.yaml file' do
       it 'does bolt_run_script against localhost without error' do
         stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'localhost'))
+        expect(File).to receive(:exist?).with('inventory.yaml').and_return(false)
+        expect(dummy_class).to receive(:localhost_inventory_hash).and_return(localhost_inventory_hash)
         expect(dummy_class).not_to receive(:inventory_hash_from_inventory_file)
-        expect(dummy_class).to receive(:run_script).with(script, 'localhost', [], options: {}, config: nil, inventory: nil).and_return(result)
+        expect(dummy_class).to receive(:target_in_inventory?).and_return(true)
+        expect(dummy_class).to receive(:run_script).with(script, 'litmus_localhost', [], options: {}, config: nil, inventory: localhost_inventory_hash).and_return(result)
         expect { dummy_class.bolt_run_script(script) }.not_to raise_error
       end
     end
@@ -131,7 +155,9 @@ RSpec.describe PuppetLitmus::Serverspec do
     context 'when running against remote host' do
       it 'does bolt_run_script against remote host without error' do
         stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
+        expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file)
+        expect(dummy_class).to receive(:target_in_inventory?).and_return(true)
         expect(dummy_class).to receive(:run_script).with(script, 'some.host', [], options: {}, config: nil, inventory: nil).and_return(result)
         expect { dummy_class.bolt_run_script(script) }.not_to raise_error
       end
@@ -140,8 +166,11 @@ RSpec.describe PuppetLitmus::Serverspec do
     context 'when running with arguments' do
       it 'does bolt_run_script with arguments without error' do
         stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'localhost'))
+        expect(File).to receive(:exist?).with('inventory.yaml').and_return(false)
+        expect(dummy_class).to receive(:localhost_inventory_hash).and_return(localhost_inventory_hash)
         expect(dummy_class).not_to receive(:inventory_hash_from_inventory_file)
-        expect(dummy_class).to receive(:run_script).with(script, 'localhost', ['doot'], options: {}, config: nil, inventory: nil).and_return(result)
+        expect(dummy_class).to receive(:target_in_inventory?).and_return(true)
+        expect(dummy_class).to receive(:run_script).with(script, 'litmus_localhost', ['doot'], options: {}, config: nil, inventory: localhost_inventory_hash).and_return(result)
         expect { dummy_class.bolt_run_script(script, arguments: ['doot']) }.not_to raise_error
       end
     end
@@ -157,7 +186,7 @@ RSpec.describe PuppetLitmus::Serverspec do
     let(:result_structured_task_success){ [{'node'=>'some.host','target'=>'some.host','action'=>'task','object'=>'testtask::structured','status'=>'success','result'=>{'key1'=>'foo','key2'=>'bar'}}]}
     let(:result_failure) {[{'node'=>'some.host','target'=>'some.host','action'=>'task','object'=>'testtask::unstructured','status'=>'failure','result'=>{'_error'=>{'msg'=>'FAILURE!','kind'=>'puppetlabs.tasks/task-error','details'=>{'exitcode'=>123}}}}]}
     # rubocop:enable SpaceInsideHashLiteralBraces, SpaceBeforeBlockBraces, SpaceInsideBlockBraces, SpaceAroundOperators, LineLength, SpaceAfterComma
-    let(:inventory_hash) { Hash.new(0) }
+    let(:inventory_hash) { { 'groups' => [{ 'name' => 'local', 'nodes' => [{ 'name' => 'some.host', 'config' => { 'transport' => 'local' } }] }] } }
 
     it 'responds to bolt_run_task' do
       expect(dummy_class).to respond_to(:run_bolt_task).with(2..3).arguments
@@ -166,20 +195,26 @@ RSpec.describe PuppetLitmus::Serverspec do
     context 'when bolt returns success' do
       it 'does bolt_task_run gives no runtime error for success' do
         stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
+        expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
+        expect(dummy_class).to receive(:target_in_inventory?).and_return(true)
         expect(dummy_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_unstructured_task_success)
         expect { dummy_class.run_bolt_task(task_name, params, opts: {}) }.not_to raise_error
       end
       it 'returns stdout for unstructured-data tasks' do
         stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
+        expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
+        expect(dummy_class).to receive(:target_in_inventory?).and_return(true)
         expect(dummy_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_unstructured_task_success)
         method_result = dummy_class.run_bolt_task(task_name, params, opts: {})
         expect(method_result.stdout).to eq('SUCCESS!')
       end
       it 'returns structured output for structured-data tasks' do
         stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
+        expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
+        expect(dummy_class).to receive(:target_in_inventory?).and_return(true)
         expect(dummy_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_structured_task_success)
         method_result = dummy_class.run_bolt_task(task_name, params, opts: {})
         expect(method_result.stdout).to eq('{"key1"=>"foo", "key2"=>"bar"}')
@@ -191,13 +226,17 @@ RSpec.describe PuppetLitmus::Serverspec do
     context 'when bolt returns failure' do
       it 'does bolt_task_run gives runtime error for failure' do
         stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
+        expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
+        expect(dummy_class).to receive(:target_in_inventory?).and_return(true)
         expect(dummy_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_failure)
         expect { dummy_class.run_bolt_task(task_name, params, opts: {}) }.to raise_error(RuntimeError, %r{task failed})
       end
       it 'returns the exit code and error message when expecting failure' do
         stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
+        expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(dummy_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
+        expect(dummy_class).to receive(:target_in_inventory?).and_return(true)
         expect(dummy_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_failure)
         method_result = dummy_class.run_bolt_task(task_name, params, expect_failures: true)
         expect(method_result.exit_code).to be(123)


### PR DESCRIPTION
Prior to this commit it was not possible to mock features when running
acceptance tests against localhost. This is because both specifying the
node name localhost causes bolt to ignore the inventory file and also
litmus passed an empty inventory file when calling the helpers against
localhost as the target node.

This commit makes some extensive additions and patches to the existing
behavior in order to enable mocking localhost during testing:

- It adds localhost_inventory_hash as a method in inventory_manipulation,
  which will return a valid inventory hash containing only what bolt
  needs to execute locally; it places the node litmus_localhost in
  the local group and specifies the transport as local. This node CAN
  NOT be named localhost or bolt will ignore the inventory file.
- It adds the target_in_inventory? helper in inventory_manipulation,
  which will check to see if the specified node name is in the inventory
  and return true if it does or false if it does not.
- It adds the targeting_localhost? helper in serverspec which replaces
  the logic reused throughout the serverspec methods for determining if
  the command is being used against localhost.
- It updates the logic in the serverspec methods to set the target node
  name to litmus_localhost if the target is localhost, allowing the
  helpers to use the mockable entry in the inventory hash.
- It updates the logic in the serverspec methods to use the inventory
  file if it exists and to substitute the basic localhost inventory
  hash if it does not.
- It updates the logic in the serverspec methods to raise an error if
  the target node is not specified in the inventory hash; previously,
  specifying a target not found in the inventory hash could lead to
  errors in the actual execution which could be hard to parse.

These changes make it possible to mock features and other inventory
details when executing acceptance tests against a localhost using the
litmus library.