### PR TITLE
(bugfix) Report both stderr and stdout when an error is detected

### DIFF
--- a/lib/puppet_litmus/serverspec.rb
+++ b/lib/puppet_litmus/serverspec.rb
@@ -251,7 +251,8 @@ module PuppetLitmus::Serverspec
 
   # Return the stdout of the puppet run
   def puppet_output(result)
-    result.dig(0, 'result', 'stdout').to_s
+    result.dig(0, 'result', 'stderr').to_s << \
+      result.dig(0, 'result', 'stdout').to_s
   end
 
   # Checks a puppet return status and returns true if it both


### PR DESCRIPTION
Before only the stdout was reported. This is confusing when a syntax error is in the puppet code.  The output is then empty, but the stderr reports the error