### PR TITLE
(MAINT) Fix undeclared dependencies

### DIFF
--- a/puppet_litmus.gemspec
+++ b/puppet_litmus.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'pdk',         ['>= 1.10.0', '< 2.0.0']
   spec.add_runtime_dependency 'tty-spinner', ['>= 0.5.0', '< 1.0.0']
   spec.add_runtime_dependency 'docker-api',  ['>= 1.34', '< 2.0.0']
+  spec.add_runtime_dependency 'parallel'
+  spec.add_runtime_dependency 'rspec'
 end


### PR DESCRIPTION
The gemspec does not mention that this gem requires `parallel` and
`rspec`. Most users don't notice because those gems are already brought
in by other dependencies in the typical module's Gemfile.

The issue is when someone wants to leverage Litmus, but they aren't
doing modulet testing and want to avoid installing those other module
testing gems when they aren't needed, then the Litmus gem will fail to
install if `parallel` and `rspec` are not specifically added to the
Gemfile.

This change declares those two dependencies explicitly in the gemspec to
avoid this issue.