### PR TITLE
(maint) Lazily load gems in rake tasks

### DIFF
--- a/lib/puppet_litmus/inventory_manipulation.rb
+++ b/lib/puppet_litmus/inventory_manipulation.rb
@@ -252,6 +252,6 @@ module PuppetLitmus::InventoryManipulation
   #  @param inventory_hash [Hash] hash of the inventory.yaml file
   #  @return inventory.yaml file with feature added to group.
   def write_to_inventory_file(inventory_hash, inventory_full_path)
-    File.open(inventory_full_path, 'w+') { |f| f.write(inventory_hash.to_yaml) }
+    File.open(inventory_full_path, 'wb+') { |f| f.write(inventory_hash.to_yaml) }
   end
 end

--- a/lib/puppet_litmus/inventory_manipulation.rb
+++ b/lib/puppet_litmus/inventory_manipulation.rb
@@ -7,6 +7,7 @@ module PuppetLitmus::InventoryManipulation
   # @param inventory_full_path [String] path to the inventory.yaml file
   # @return [Hash] hash of the inventory.yaml file.
   def inventory_hash_from_inventory_file(inventory_full_path = nil)
+    require 'yaml'
     inventory_full_path = if inventory_full_path.nil?
                             'inventory.yaml'
                           else
@@ -44,6 +45,7 @@ module PuppetLitmus::InventoryManipulation
   # @param targets [Array]
   # @return [Array] array of targets.
   def find_targets(inventory_hash, targets)
+    require 'bolt/inventory'
     if targets.nil?
       inventory = Bolt::Inventory.new(inventory_hash, nil)
       targets = inventory.node_names.to_a

--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'bolt_spec/run'
-require 'open3'
-
 # helper methods for the litmus rake tasks
 module PuppetLitmus::RakeHelper
   DEFAULT_CONFIG_DATA ||= { 'modulepath' => File.join(Dir.pwd, 'spec', 'fixtures', 'modules') }.freeze
@@ -53,6 +50,7 @@ module PuppetLitmus::RakeHelper
   # @param command [String] command to execute.
   # @return [Object] the standard out stream.
   def run_local_command(command)
+    require 'open3'
     stdout, stderr, status = Open3.capture3(command)
     error_message = "Attempted to run\ncommand:'#{command}'\nstdout:#{stdout}\nstderr:#{stderr}"
     raise error_message unless status.to_i.zero?
@@ -86,6 +84,7 @@ module PuppetLitmus::RakeHelper
   end
 
   def provision(provisioner, platform, inventory_vars)
+    require 'bolt_spec/run'
     include BoltSpec::Run
     raise "the provision module was not found in #{DEFAULT_CONFIG_DATA['modulepath']}, please amend the .fixtures.yml file" unless
       File.directory?(File.join(DEFAULT_CONFIG_DATA['modulepath'], 'provision'))
@@ -115,6 +114,7 @@ module PuppetLitmus::RakeHelper
   end
 
   def tear_down_nodes(targets, inventory_hash)
+    require 'bolt_spec/run'
     include BoltSpec::Run
     config_data = { 'modulepath' => File.join(Dir.pwd, 'spec', 'fixtures', 'modules') }
     raise "the provision module was not found in #{config_data['modulepath']}, please amend the .fixtures.yml file" unless File.directory?(File.join(config_data['modulepath'], 'provision'))
@@ -139,6 +139,7 @@ module PuppetLitmus::RakeHelper
   end
 
   def install_agent(collection, targets, inventory_hash)
+    require 'bolt_spec/run'
     include BoltSpec::Run
     params = if collection.nil?
                {}
@@ -173,6 +174,7 @@ module PuppetLitmus::RakeHelper
   end
 
   def install_module(inventory_hash, target_node_name, module_tar)
+    require 'bolt_spec/run'
     include BoltSpec::Run
     target_nodes = find_targets(inventory_hash, target_node_name)
     target_string = if target_node_name.nil?
@@ -196,6 +198,7 @@ module PuppetLitmus::RakeHelper
   end
 
   def uninstall_module(inventory_hash, target_node_name, module_to_remove = nil)
+    require 'bolt_spec/run'
     include BoltSpec::Run
     module_name = module_to_remove || metadata_module_name
     target_nodes = find_targets(inventory_hash, target_node_name)


### PR DESCRIPTION
Previously the Litmus rake tasks loaded every single gem whether it was needed
or not. This bloats simple commans like "rake -T". As an example, on
puppetlabs-inifile, it takes 2 seconds to just list the available rake tasks.
While this number seems initially small, when combined with all the other rake
tasks a Puppet module developer brings in, any time saving is useful.

This commit changes the loading behaviour to require gems when needed, not all
at the top of the rake_tasks.rb file. Note that some helper files were also
modified for the same lazy loading behaviour as they are consumed by the rake
tasks.