### PR TITLE
(MODULES-10018) Contain BoltSpec::Run methods

### DIFF
--- a/lib/puppet_litmus.rb
+++ b/lib/puppet_litmus.rb
@@ -11,7 +11,18 @@ require 'puppet_litmus/spec_helper_acceptance'
 
 # Helper methods for testing puppet content
 module PuppetLitmus
-  include BoltSpec::Run
+  # Container class for BoltSpec::Run methods to avoid leaking them via include
+  class BoltSpecRun
+    include BoltSpec::Run
+  end
+
+  # Method for shortening the reference to the BoltSpec::Run methods, memoized.
+  #
+  # @return [PuppetLitmus::BoltSpecRun] instance of the bolt_spec container class
+  def self.bolt
+    @bolt ||= BoltSpecRun.new
+  end
+
   include PuppetLitmus::InventoryManipulation
   include PuppetLitmus::PuppetHelpers
   include PuppetLitmus::RakeHelper

--- a/lib/puppet_litmus/puppet_helpers.rb
+++ b/lib/puppet_litmus/puppet_helpers.rb
@@ -71,7 +71,7 @@ module PuppetLitmus::PuppetHelpers
     command_to_run += ' --noop' if !opts[:noop].nil? && (opts[:noop] == true)
     command_to_run += ' --detailed-exitcodes' if use_detailed_exit_codes == true
 
-    result = run_command(command_to_run, target_node_name, config: nil, inventory: inventory_hash)
+    result = PuppetLitmus.bolt.run_command(command_to_run, target_node_name, config: nil, inventory: inventory_hash)
     status = result.first['result']['exit_code']
     if opts[:catch_changes] && !acceptable_exit_codes.include?(status)
       report_puppet_apply_change(command_to_run, result)
@@ -109,7 +109,7 @@ module PuppetLitmus::PuppetHelpers
       # transfer to TARGET_HOST
       inventory_hash = inventory_hash_from_inventory_file
       manifest_file_location = "/tmp/#{File.basename(manifest_file)}"
-      result = upload_file(manifest_file.path, manifest_file_location, target_node_name, options: {}, config: nil, inventory: inventory_hash)
+      result = PuppetLitmus.bolt.upload_file(manifest_file.path, manifest_file_location, target_node_name, options: {}, config: nil, inventory: inventory_hash)
       raise result.first['result'].to_s unless result.first['status'] == 'success'
     end
     manifest_file_location
@@ -126,7 +126,7 @@ module PuppetLitmus::PuppetHelpers
     inventory_hash = File.exist?('inventory.yaml') ? inventory_hash_from_inventory_file : localhost_inventory_hash
     raise "Target '#{target_node_name}' not found in inventory.yaml" unless target_in_inventory?(inventory_hash, target_node_name)
 
-    result = run_command(command_to_run, target_node_name, config: nil, inventory: inventory_hash)
+    result = PuppetLitmus.bolt.run_command(command_to_run, target_node_name, config: nil, inventory: inventory_hash)
     raise "shell failed\n`#{command_to_run}`\n======\n#{result}" if result.first['result']['exit_code'] != 0 && opts[:expect_failures] != true
 
     result = OpenStruct.new(exit_code: result.first['result']['exit_code'],
@@ -149,7 +149,7 @@ module PuppetLitmus::PuppetHelpers
     inventory_hash = File.exist?('inventory.yaml') ? inventory_hash_from_inventory_file : localhost_inventory_hash
     raise "Target '#{target_node_name}' not found in inventory.yaml" unless target_in_inventory?(inventory_hash, target_node_name)
 
-    result = upload_file(source, destination, target_node_name, options: options, config: nil, inventory: inventory_hash)
+    result = PuppetLitmus.bolt.upload_file(source, destination, target_node_name, options: options, config: nil, inventory: inventory_hash)
 
     result_obj = {
       exit_code: 0,
@@ -195,7 +195,7 @@ module PuppetLitmus::PuppetHelpers
                      end
     raise "Target '#{target_node_name}' not found in inventory.yaml" unless target_in_inventory?(inventory_hash, target_node_name)
 
-    result = run_task(task_name, target_node_name, params, config: config_data, inventory: inventory_hash)
+    result = PuppetLitmus.bolt.run_task(task_name, target_node_name, params, config: config_data, inventory: inventory_hash)
     result_obj = {
       exit_code: 0,
       stdout: nil,
@@ -242,7 +242,7 @@ module PuppetLitmus::PuppetHelpers
     inventory_hash = File.exist?('inventory.yaml') ? inventory_hash_from_inventory_file : localhost_inventory_hash
     raise "Target '#{target_node_name}' not found in inventory.yaml" unless target_in_inventory?(inventory_hash, target_node_name)
 
-    result = run_script(script, target_node_name, arguments, options: opts, config: nil, inventory: inventory_hash)
+    result = PuppetLitmus.bolt.run_script(script, target_node_name, arguments, options: opts, config: nil, inventory: inventory_hash)
 
     raise "script run failed\n`#{script}`\n======\n#{result}" if result.first['result']['exit_code'] != 0 && opts[:expect_failures] != true
 

--- a/spec/lib/puppet_litmus/puppet_helpers_spec.rb
+++ b/spec/lib/puppet_litmus/puppet_helpers_spec.rb
@@ -122,10 +122,10 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
     let(:local) { '/tmp' }
     let(:remote) { '/remote_tmp' }
     # Ignore rubocop because these hashes are representative of output from an external method and editing them leads to test failures.
-    # rubocop:disable SpaceInsideHashLiteralBraces, SpaceInsideBlockBraces, SpaceAroundOperators, LineLength, SpaceAfterComma
+    # rubocop:disable Layout/SpaceInsideHashLiteralBraces, Layout/SpaceInsideBlockBraces, Layout/SpaceAroundOperators, Metrics/LineLength, Layout/SpaceAfterComma
     let(:result_success) {[{'node'=>'some.host','target'=>'some.host','action'=>'upload','object'=>'C:\foo\bar.ps1','status'=>'success','result'=>{'_output'=>'Uploaded \'C:\foo\bar.ps1\' to \'some.host:C:\bar\''}}]}
     let(:result_failure) {[{'node'=>'some.host','target'=>'some.host','action'=>nil,'object'=>nil,'status'=>'failure','result'=>{'_error'=>{'kind'=>'puppetlabs.tasks/task_file_error','msg'=>'No such file or directory @ rb_sysopen - /nonexistant/file/path','details'=>{},'issue_code'=>'WRITE_ERROR'}}}]}
-    # rubocop:enable SpaceInsideHashLiteralBraces, SpaceInsideBlockBraces, SpaceAroundOperators, LineLength, SpaceAfterComma
+    # rubocop:enable Layout/SpaceInsideHashLiteralBraces, Layout/SpaceInsideBlockBraces, Layout/SpaceAroundOperators, Metrics/LineLength, Layout/SpaceAfterComma
     let(:inventory_hash) { { 'groups' => [{ 'name' => 'local', 'nodes' => [{ 'name' => 'some.host', 'config' => { 'transport' => 'local' } }] }] } }
     let(:localhost_inventory_hash) { { 'groups' => [{ 'name' => 'local', 'nodes' => [{ 'name' => 'litmus_localhost', 'config' => { 'transport' => 'local' } }] }] } }
 
@@ -228,11 +228,11 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
     let(:params) { { 'action' => 'install', 'name' => 'foo' } }
     let(:config_data) { { 'modulepath' => File.join(Dir.pwd, 'spec', 'fixtures', 'modules') } }
     # Ignore rubocop because these hashes are representative of output from an external method and editing them leads to test failures.
-    # rubocop:disable SpaceInsideHashLiteralBraces, SpaceBeforeBlockBraces, SpaceInsideBlockBraces, SpaceAroundOperators, LineLength, SpaceAfterComma
+    # rubocop:disable Layout/SpaceInsideHashLiteralBraces, Layout/SpaceBeforeBlockBraces, Layout/SpaceInsideBlockBraces, Layout/SpaceAroundOperators, Metrics/LineLength, Layout/SpaceAfterComma
     let(:result_unstructured_task_success){ [{'node'=>'some.host','target'=>'some.host','action'=>'task','object'=>'testtask::unstructured','status'=>'success','result'=>{'_output'=>'SUCCESS!'}}]}
     let(:result_structured_task_success){ [{'node'=>'some.host','target'=>'some.host','action'=>'task','object'=>'testtask::structured','status'=>'success','result'=>{'key1'=>'foo','key2'=>'bar'}}]}
     let(:result_failure) {[{'node'=>'some.host','target'=>'some.host','action'=>'task','object'=>'testtask::unstructured','status'=>'failure','result'=>{'_error'=>{'msg'=>'FAILURE!','kind'=>'puppetlabs.tasks/task-error','details'=>{'exitcode'=>123}}}}]}
-    # rubocop:enable SpaceInsideHashLiteralBraces, SpaceBeforeBlockBraces, SpaceInsideBlockBraces, SpaceAroundOperators, LineLength, SpaceAfterComma
+    # rubocop:enable Layout/SpaceInsideHashLiteralBraces, Layout/SpaceBeforeBlockBraces, Layout/SpaceInsideBlockBraces, Layout/SpaceAroundOperators, Metrics/LineLength, Layout/SpaceAfterComma
     let(:inventory_hash) { { 'groups' => [{ 'name' => 'local', 'nodes' => [{ 'name' => 'some.host', 'config' => { 'transport' => 'local' } }] }] } }
 
     it 'responds to bolt_run_task' do

--- a/spec/lib/puppet_litmus/puppet_helpers_spec.rb
+++ b/spec/lib/puppet_litmus/puppet_helpers_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(described_class).to receive(:localhost_inventory_hash).and_return(localhost_inventory_hash)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
         expect(described_class).to receive(:create_manifest_file).with(manifest).and_return('/bla.pp')
-        expect(described_class).to receive(:run_command).with(command, 'litmus_localhost', config: nil, inventory: localhost_inventory_hash).and_return(result)
+        expect(PuppetLitmus.bolt).to receive(:run_command).with(command, 'litmus_localhost', config: nil, inventory: localhost_inventory_hash).and_return(result)
         described_class.apply_manifest(manifest, hiera_config: '/hiera.yaml')
       end
     end
@@ -47,7 +47,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(described_class).to receive(:localhost_inventory_hash).and_return(localhost_inventory_hash)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
         expect(described_class).to receive(:create_manifest_file).with(manifest).and_return('/bla.pp')
-        expect(described_class).to receive(:run_command).with(command, 'litmus_localhost', config: nil, inventory: localhost_inventory_hash).and_return(result)
+        expect(PuppetLitmus.bolt).to receive(:run_command).with(command, 'litmus_localhost', config: nil, inventory: localhost_inventory_hash).and_return(result)
         expect { described_class.apply_manifest(manifest, expect_failures: true) }.to raise_error(RuntimeError)
       end
 
@@ -56,7 +56,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(described_class).to receive(:localhost_inventory_hash).and_return(localhost_inventory_hash)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
         expect(described_class).to receive(:create_manifest_file).with(manifest).and_return('/bla.pp')
-        expect(described_class).to receive(:run_command).with(command, 'litmus_localhost', config: nil, inventory: localhost_inventory_hash).and_return(result)
+        expect(PuppetLitmus.bolt).to receive(:run_command).with(command, 'litmus_localhost', config: nil, inventory: localhost_inventory_hash).and_return(result)
         described_class.apply_manifest(manifest, catch_failures: true)
       end
 
@@ -65,7 +65,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(described_class).to receive(:localhost_inventory_hash).and_return(localhost_inventory_hash)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
         expect(described_class).to receive(:create_manifest_file).with(manifest).and_return('/bla.pp')
-        expect(described_class).to receive(:run_command).with(command, 'litmus_localhost', config: nil, inventory: localhost_inventory_hash).and_return(result)
+        expect(PuppetLitmus.bolt).to receive(:run_command).with(command, 'litmus_localhost', config: nil, inventory: localhost_inventory_hash).and_return(result)
         expect { described_class.apply_manifest(manifest, expect_changes: true) }.to raise_error(RuntimeError)
       end
 
@@ -74,7 +74,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(described_class).to receive(:localhost_inventory_hash).and_return(localhost_inventory_hash)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
         expect(described_class).to receive(:create_manifest_file).with(manifest).and_return('/bla.pp')
-        expect(described_class).to receive(:run_command).with(command, 'litmus_localhost', config: nil, inventory: localhost_inventory_hash).and_return(result)
+        expect(PuppetLitmus.bolt).to receive(:run_command).with(command, 'litmus_localhost', config: nil, inventory: localhost_inventory_hash).and_return(result)
         described_class.apply_manifest(manifest, catch_changes: true)
       end
 
@@ -101,7 +101,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(File).to receive(:exist?).with('inventory.yaml').and_return(false)
         expect(described_class).to receive(:localhost_inventory_hash).and_return(localhost_inventory_hash)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
-        expect(described_class).to receive(:run_command).with(command_to_run, 'litmus_localhost', config: nil, inventory: localhost_inventory_hash).and_return(result)
+        expect(PuppetLitmus.bolt).to receive(:run_command).with(command_to_run, 'litmus_localhost', config: nil, inventory: localhost_inventory_hash).and_return(result)
         expect { described_class.run_shell(command_to_run) }.not_to raise_error
       end
     end
@@ -112,7 +112,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(described_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
-        expect(described_class).to receive(:run_command).with(command_to_run, 'some.host', config: nil, inventory: inventory_hash).and_return(result)
+        expect(PuppetLitmus.bolt).to receive(:run_command).with(command_to_run, 'some.host', config: nil, inventory: inventory_hash).and_return(result)
         expect { described_class.run_shell(command_to_run) }.not_to raise_error
       end
     end
@@ -139,7 +139,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(described_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
-        expect(described_class).to receive(:upload_file).with(local, remote, 'some.host', options: {}, config: nil, inventory: inventory_hash).and_return(result_success)
+        expect(PuppetLitmus.bolt).to receive(:upload_file).with(local, remote, 'some.host', options: {}, config: nil, inventory: inventory_hash).and_return(result_success)
         expect { described_class.bolt_upload_file(local, remote) }.not_to raise_error
       end
 
@@ -149,7 +149,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(described_class).to receive(:localhost_inventory_hash).and_return(localhost_inventory_hash)
         expect(described_class).not_to receive(:inventory_hash_from_inventory_file)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
-        expect(described_class).to receive(:upload_file).with(local, remote, 'litmus_localhost', options: {}, config: nil, inventory: localhost_inventory_hash).and_return(result_success)
+        expect(PuppetLitmus.bolt).to receive(:upload_file).with(local, remote, 'litmus_localhost', options: {}, config: nil, inventory: localhost_inventory_hash).and_return(result_success)
         expect { described_class.bolt_upload_file(local, remote) }.not_to raise_error
       end
     end
@@ -160,7 +160,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(described_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
-        expect(described_class).to receive(:upload_file).with(local, remote, 'some.host', options: {}, config: nil, inventory: inventory_hash).and_return(result_failure)
+        expect(PuppetLitmus.bolt).to receive(:upload_file).with(local, remote, 'some.host', options: {}, config: nil, inventory: inventory_hash).and_return(result_failure)
         expect { described_class.bolt_upload_file(local, remote) }.to raise_error(RuntimeError, %r{upload file failed})
       end
 
@@ -169,7 +169,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(described_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
-        expect(described_class).to receive(:upload_file).with(local, remote, 'some.host', options: {}, config: nil, inventory: inventory_hash).and_return(result_failure)
+        expect(PuppetLitmus.bolt).to receive(:upload_file).with(local, remote, 'some.host', options: {}, config: nil, inventory: inventory_hash).and_return(result_failure)
         method_result = described_class.bolt_upload_file(local, remote, expect_failures: true)
         expect(method_result.exit_code).to be(255)
         expect(method_result.stderr).to be('No such file or directory @ rb_sysopen - /nonexistant/file/path')
@@ -194,7 +194,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(described_class).to receive(:localhost_inventory_hash).and_return(localhost_inventory_hash)
         expect(described_class).not_to receive(:inventory_hash_from_inventory_file)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
-        expect(described_class).to receive(:run_script).with(script, 'litmus_localhost', [], options: {}, config: nil, inventory: localhost_inventory_hash).and_return(result)
+        expect(PuppetLitmus.bolt).to receive(:run_script).with(script, 'litmus_localhost', [], options: {}, config: nil, inventory: localhost_inventory_hash).and_return(result)
         expect { described_class.bolt_run_script(script) }.not_to raise_error
       end
     end
@@ -205,7 +205,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(described_class).to receive(:inventory_hash_from_inventory_file)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
-        expect(described_class).to receive(:run_script).with(script, 'some.host', [], options: {}, config: nil, inventory: nil).and_return(result)
+        expect(PuppetLitmus.bolt).to receive(:run_script).with(script, 'some.host', [], options: {}, config: nil, inventory: nil).and_return(result)
         expect { described_class.bolt_run_script(script) }.not_to raise_error
       end
     end
@@ -217,7 +217,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(described_class).to receive(:localhost_inventory_hash).and_return(localhost_inventory_hash)
         expect(described_class).not_to receive(:inventory_hash_from_inventory_file)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
-        expect(described_class).to receive(:run_script).with(script, 'litmus_localhost', ['doot'], options: {}, config: nil, inventory: localhost_inventory_hash).and_return(result)
+        expect(PuppetLitmus.bolt).to receive(:run_script).with(script, 'litmus_localhost', ['doot'], options: {}, config: nil, inventory: localhost_inventory_hash).and_return(result)
         expect { described_class.bolt_run_script(script, arguments: ['doot']) }.not_to raise_error
       end
     end
@@ -245,7 +245,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(described_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
-        expect(described_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_unstructured_task_success)
+        expect(PuppetLitmus.bolt).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_unstructured_task_success)
         expect { described_class.run_bolt_task(task_name, params, opts: {}) }.not_to raise_error
       end
 
@@ -254,7 +254,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(File).to receive(:exist?).with('jim.yaml').and_return(true)
         expect(described_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
-        expect(described_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_unstructured_task_success)
+        expect(PuppetLitmus.bolt).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_unstructured_task_success)
         expect { described_class.run_bolt_task(task_name, params, inventory_file: 'jim.yaml') }.not_to raise_error
       end
 
@@ -263,7 +263,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(described_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
-        expect(described_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_unstructured_task_success)
+        expect(PuppetLitmus.bolt).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_unstructured_task_success)
         method_result = described_class.run_bolt_task(task_name, params, opts: {})
         expect(method_result.stdout).to eq('SUCCESS!')
       end
@@ -273,7 +273,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(described_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
-        expect(described_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_structured_task_success)
+        expect(PuppetLitmus.bolt).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_structured_task_success)
         method_result = described_class.run_bolt_task(task_name, params, opts: {})
         expect(method_result.stdout).to eq('{"key1"=>"foo", "key2"=>"bar"}')
         expect(method_result.result['key1']).to eq('foo')
@@ -287,7 +287,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(described_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
-        expect(described_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_failure)
+        expect(PuppetLitmus.bolt).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_failure)
         expect { described_class.run_bolt_task(task_name, params, opts: {}) }.to raise_error(RuntimeError, %r{task failed})
       end
 
@@ -296,7 +296,7 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
         expect(File).to receive(:exist?).with('inventory.yaml').and_return(true)
         expect(described_class).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
         expect(described_class).to receive(:target_in_inventory?).and_return(true)
-        expect(described_class).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_failure)
+        expect(PuppetLitmus.bolt).to receive(:run_task).with(task_name, 'some.host', params, config: config_data, inventory: inventory_hash).and_return(result_failure)
         method_result = described_class.run_bolt_task(task_name, params, expect_failures: true)
         expect(method_result.exit_code).to be(123)
         expect(method_result.stderr).to be('FAILURE!')

--- a/spec/lib/puppet_litmus/rake_helper_spec.rb
+++ b/spec/lib/puppet_litmus/rake_helper_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe PuppetLitmus::RakeHelper do
     it 'calls function' do
       allow(File).to receive(:directory?).and_call_original
       allow(File).to receive(:directory?).with(File.join(DEFAULT_CONFIG_DATA['modulepath'], 'provision')).and_return(true)
-      allow_any_instance_of(BoltSpec::Run).to receive(:run_task).with('provision::docker', 'localhost', params, config: DEFAULT_CONFIG_DATA, inventory: nil).and_return(results)
+      allow(PuppetLitmus.bolt).to receive(:run_task).with('provision::docker', 'localhost', params, config: DEFAULT_CONFIG_DATA, inventory: nil).and_return(results)
       described_class.provision('docker', 'waffleimage/centos7', nil)
     end
   end
@@ -39,7 +39,7 @@ RSpec.describe PuppetLitmus::RakeHelper do
 
     it 'calls function' do
       allow(File).to receive(:directory?).with(File.join(DEFAULT_CONFIG_DATA['modulepath'], 'provision')).and_return(true)
-      allow_any_instance_of(BoltSpec::Run).to receive(:run_task).with('provision::docker', 'localhost', params, config: DEFAULT_CONFIG_DATA, inventory: nil).and_return([])
+      allow(PuppetLitmus.bolt).to receive(:run_task).with('provision::docker', 'localhost', params, config: DEFAULT_CONFIG_DATA, inventory: nil).and_return([])
       described_class.tear_down_nodes(targets, inventory_hash)
     end
   end
@@ -55,7 +55,7 @@ RSpec.describe PuppetLitmus::RakeHelper do
 
     it 'calls function' do
       allow(File).to receive(:directory?).with(File.join(DEFAULT_CONFIG_DATA['modulepath'], 'puppet_agent')).and_return(true)
-      allow_any_instance_of(BoltSpec::Run).to receive(:run_task).with('puppet_agent::install', targets, params, config: DEFAULT_CONFIG_DATA, inventory: inventory_hash).and_return([])
+      allow(PuppetLitmus.bolt).to receive(:run_task).with('puppet_agent::install', targets, params, config: DEFAULT_CONFIG_DATA, inventory: inventory_hash).and_return([])
       described_class.install_agent('puppet6', targets, inventory_hash)
     end
   end
@@ -73,7 +73,7 @@ RSpec.describe PuppetLitmus::RakeHelper do
     it 'calls function' do
       allow(Open3).to receive(:capture3).with("bundle exec bolt file upload \"#{module_tar}\" /tmp/#{File.basename(module_tar)} --nodes all --inventoryfile inventory.yaml")
                                         .and_return(['success', '', 0])
-      allow_any_instance_of(BoltSpec::Run).to receive(:run_command).with(install_module_command, targets, config: nil, inventory: inventory_hash).and_return([])
+      allow(PuppetLitmus.bolt).to receive(:run_command).with(install_module_command, targets, config: nil, inventory: inventory_hash).and_return([])
       described_class.install_module(inventory_hash, nil, module_tar)
     end
   end
@@ -88,13 +88,13 @@ RSpec.describe PuppetLitmus::RakeHelper do
     let(:uninstall_module_command) { 'puppet module uninstall foo-bar' }
 
     it 'uninstalls module' do
-      allow_any_instance_of(BoltSpec::Run).to receive(:run_command).with(uninstall_module_command, targets, config: nil, inventory: inventory_hash).and_return([])
+      allow(PuppetLitmus.bolt).to receive(:run_command).with(uninstall_module_command, targets, config: nil, inventory: inventory_hash).and_return([])
       expect(described_class).to receive(:metadata_module_name).and_return('foo-bar')
       described_class.uninstall_module(inventory_hash, nil)
     end
 
     it 'and custom name' do
-      allow_any_instance_of(BoltSpec::Run).to receive(:run_command).with(uninstall_module_command, targets, config: nil, inventory: inventory_hash).and_return([])
+      allow(PuppetLitmus.bolt).to receive(:run_command).with(uninstall_module_command, targets, config: nil, inventory: inventory_hash).and_return([])
       described_class.uninstall_module(inventory_hash, nil, 'foo-bar')
     end
   end


### PR DESCRIPTION
Prior to this commit the BoltSpec::Run methods were included at the top level of the PuppetLitmus module namespace. This caused an issue when leveraging the `command()` idiom in serverspec where it attempted to resolve `run_command()` via the BoltSpec::Run method instead of the appropriate serverspec method.

This commit contains the BoltSpec::Run methods into a class and adds a shorthand reference to them for use in the rest of the PuppetLitmus namespace.  This resolves the conflicts which prevented users from leveraging idiomatic serverspec to test their modules and systems.