### PR TITLE
(feat) check connectivity status, after testing completes

### DIFF
--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -380,6 +380,7 @@ namespace :litmus do
         # output test summary
         puts "Successful on #{success_list.size} nodes: #{success_list}" if success_list.any?
         puts "Failed on #{failure_list.size} nodes: #{failure_list}" if failure_list.any?
+        Rake::Task['litmus:check_connectivity'].invoke
         exit 1 if failure_list.any?
       end
 


### PR DESCRIPTION
```


pid 25464 exit 1
Failed on 15 nodes: ["syrupy-nod.delivery.puppetlabs.net, ubuntu-1804-x86_64", "liberal-ante.delivery.puppetlabs.net, debian-10-x86_64", "amen-shore.delivery.puppetlabs.net, ubuntu-1404-x86_64", "crumbly-gait.delivery.puppetlabs.net, debian-9-x86_64", "distal-lime.delivery.puppetlabs.net, oracle-7-x86_64", "mobile-secret.delivery.puppetlabs.net, sles-15-x86_64", "irate-guinea.delivery.puppetlabs.net, sles-11-x86_64", "fecund-pickaxe.delivery.puppetlabs.net, redhat-6-x86_64", "aloof-agnomen.delivery.puppetlabs.net, redhat-5-x86_64", "logical-clock.delivery.puppetlabs.net, scientific-7-x86_64", "tame-gelding.delivery.puppetlabs.net, centos-8-x86_64", "unlined-reducer.delivery.puppetlabs.net, scientific-6-x86_64", "jittery-cistern.delivery.puppetlabs.net, redhat-8-x86_64", "lumbar-mate.delivery.puppetlabs.net, oracle-6-x86_64", "remoter-prowl.delivery.puppetlabs.net, centos-5-x86_64"]
rake aborted!
Connectivity has failed on: ["distal-lime.delivery.puppetlabs.net"]
/home/tp/workspace/puppet_litmus/lib/puppet_litmus/rake_helper.rb:220:in `check_connectivity?'
/home/tp/workspace/puppet_litmus/lib/puppet_litmus/rake_tasks.rb:189:in `block (2 levels) in <top (required)>'
/home/tp/workspace/puppet_litmus/lib/puppet_litmus/rake_tasks.rb:383:in `block (3 levels) in <top (required)>'
/home/tp/workspace/puppetlabs-apache/.bundle/gems/ruby/2.5.0/gems/rake-12.3.3/exe/rake:27:in `<top (required)>'
/home/tp/.rbenv/versions/2.5.3/bin/bundle:23:in `load'
/home/tp/.rbenv/versions/2.5.3/bin/bundle:23:in `<main>'
Tasks: TOP => litmus:check_connectivity
(See full trace by running task with --trace)
➜  puppetlabs-apache git:(pdksync_litmus_test) ✗
```