### PR TITLE
(GH-234) Remove PDK dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :test do
   gem 'rubocop-rspec', '~> 1.38'
   gem 'codecov', '~> 0.1'
   gem 'simplecov', '~> 0.18'
- end
+end
 
 group :development do
   # TODO: Use gem instead of git. Section mapping is merged into master, but not yet released

--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -232,9 +232,7 @@ namespace :litmus do
       exit 0
     end
 
-    opts = {}
-    opts[:force] = true
-    module_tar = build_module(opts)
+    module_tar = build_module
     puts 'Built'
 
     # module_tar = Dir.glob('pkg/*.tar.gz').max_by { |f| File.mtime(f) }

--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rake'
+
 namespace :litmus do
   require 'puppet_litmus/inventory_manipulation'
   require 'puppet_litmus/rake_helper'

--- a/puppet_litmus.gemspec
+++ b/puppet_litmus.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   EOF
   spec.summary = 'Providing a simple command line tool for puppet content creators, to enable simple and complex test deployments.'
   spec.add_runtime_dependency 'bolt',        ['>= 1.13.1', '< 2.0.0']
-  spec.add_runtime_dependency 'pdk',         ['>= 1.10.0', '< 2.0.0']
+  spec.add_runtime_dependency 'puppet-modulebuilder', '~> 0.1'
   spec.add_runtime_dependency 'tty-spinner', ['>= 0.5.0', '< 1.0.0']
   spec.add_runtime_dependency 'docker-api',  ['>= 1.34', '< 2.0.0']
   spec.add_runtime_dependency 'parallel'

--- a/spec/lib/puppet_litmus/inventory_manipulation_spec.rb
+++ b/spec/lib/puppet_litmus/inventory_manipulation_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-load File.expand_path('../../../lib/puppet_litmus/inventory_manipulation.rb', __dir__)
-include PuppetLitmus::InventoryManipulation # rubocop:disable Style/MixinUsage
 
 RSpec.describe PuppetLitmus::InventoryManipulation do
   context 'with config_from_node' do

--- a/spec/lib/puppet_litmus/puppet_helpers_spec.rb
+++ b/spec/lib/puppet_litmus/puppet_helpers_spec.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-load File.expand_path('../../../lib/puppet_litmus/puppet_helpers.rb', __dir__)
-
-include PuppetLitmus::PuppetHelpers # rubocop:disable Style/MixinUsage
 
 RSpec.describe PuppetLitmus::PuppetHelpers do
   context 'with idempotent_apply' do

--- a/spec/lib/puppet_litmus/rake_helper_spec.rb
+++ b/spec/lib/puppet_litmus/rake_helper_spec.rb
@@ -2,8 +2,6 @@
 
 require 'spec_helper'
 
-load File.expand_path('../../../lib/puppet_litmus/rake_helper.rb', __dir__)
-
 RSpec.describe PuppetLitmus::RakeHelper do
   context 'with provision_list' do
     let(:provision_hash) { { 'default' => { 'provisioner' => 'docker', 'images' => ['waffleimage/centos7'] } } }

--- a/spec/lib/puppet_litmus/rake_tasks_spec.rb
+++ b/spec/lib/puppet_litmus/rake_tasks_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'rake'
-load File.expand_path('../../../lib/puppet_litmus/inventory_manipulation.rb', __dir__)
-include PuppetLitmus::InventoryManipulation # rubocop:disable Style/MixinUsage
+
 describe 'litmus rake tasks' do
   before(:all) do # rubocop:disable RSpec/BeforeAfterAll
     load File.expand_path('../../../lib/puppet_litmus/rake_tasks.rb', __dir__)

--- a/spec/lib/puppet_litmus/version_spec.rb
+++ b/spec/lib/puppet_litmus/version_spec.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-load File.expand_path('../../../lib/puppet_litmus/version.rb', __dir__)
-
-include PuppetLitmus # rubocop:disable Style/MixinUsage
 
 RSpec.describe PuppetLitmus do
   it 'has a version number' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,11 @@
 require 'rspec'
 require 'puppet_litmus'
 
+# Unfortunately this needs to be included as this is
+# how Litmus functions. We only include once here instead
+# of including for every single spec file.
+include PuppetLitmus # rubocop:disable Style/MixinUsage
+
 if ENV['COVERAGE'] == 'yes'
   require 'simplecov'
 


### PR DESCRIPTION
Block on release of the puppet-modulebuilder gem

---

Previously Litmus depended on the entire PDK gem, however it only used the
module building capability.  This commit

* Adds the puppet-modulebuilder gem into Litmus.
* Modified the rake helper to call the new Module Builder
* Modifies the gemspec to remove PDK and add the puppet-modulebuilder gem

---

TODO

- [x] Have a release of puppet-modulebuilder gem
- [x] ~~Drop the `d DROP ME` commit which is only there for testing this PR~~