### PR TITLE
(MODULES-10478) honeycomb integration to litmus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ end
 group :development do
   # TODO: Use gem instead of git. Section mapping is merged into master, but not yet released
   gem 'github_changelog_generator', git: 'https://github.com/skywinder/github-changelog-generator.git', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'
+  gem 'honeycomb-beeline'
   gem 'pry'
   gem 'yard'
 end

--- a/lib/puppet_litmus.rb
+++ b/lib/puppet_litmus.rb
@@ -8,6 +8,7 @@ require 'puppet_litmus/inventory_manipulation'
 require 'puppet_litmus/puppet_helpers'
 require 'puppet_litmus/rake_helper'
 require 'puppet_litmus/spec_helper_acceptance'
+require 'honeycomb-beeline'
 
 # Helper methods for testing puppet content
 module PuppetLitmus
@@ -15,4 +16,24 @@ module PuppetLitmus
   include PuppetLitmus::InventoryManipulation
   include PuppetLitmus::PuppetHelpers
   include PuppetLitmus::RakeHelper
+  Honeycomb.configure do |config|
+    # config.debug = true
+  end
+  process_span = Honeycomb.start_span(name: 'Litmus Testing')
+  if ENV['CI'] == 'true' && ENV['TRAVIS'] == 'true'
+    process_span.add_field('module_name', ENV['TRAVIS_REPO_SLUG'])
+    process_span.add_field('travis_build_id', ENV['TRAVIS_BUILD_ID'])
+    process_span.add_field('travis_build_web_url', ENV['TRAVIS_BUILD_WEB_URL'])
+    process_span.add_field('travis_commit_message', ENV['TRAVIS_COMMIT_MESSAGE'])
+    process_span.add_field('travis_pull_request_sha', ENV['TRAVIS_PULL_REQUEST_SHA'])
+  elsif ENV['CI'] == 'True' && ENV['APPVEYOR'] == 'True'
+    process_span.add_field('module_name', ENV['APPVEYOR_PROJECT_SLUG'])
+    process_span.add_field('appveyor_build_id', ENV['APPVEYOR_BUILD_ID'])
+    process_span.add_field('appveyor_url', "https://ci.appveyor.com/project/#{ENV['APPVEYOR_REPO_NAME']}/builds/#{ENV['APPVEYOR_BUILD_ID']}")
+    process_span.add_field('appveyor_repo_commit_message', ENV['APPVEYOR_REPO_COMMIT_MESSAGE'])
+    process_span.add_field('appveyor_pull_request_head_commit', ENV['APPVEYOR_PULL_REQUEST_HEAD_COMMIT'])
+  end
+  at_exit do
+    process_span.send
+  end
 end

--- a/lib/puppet_litmus.rb
+++ b/lib/puppet_litmus.rb
@@ -17,7 +17,6 @@ module PuppetLitmus
   include PuppetLitmus::PuppetHelpers
   include PuppetLitmus::RakeHelper
   Honeycomb.configure do |config|
-    # config.debug = true
   end
   process_span = Honeycomb.start_span(name: 'Litmus Testing')
   if ENV['CI'] == 'true' && ENV['TRAVIS'] == 'true'

--- a/puppet_litmus.gemspec
+++ b/puppet_litmus.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'docker-api',  ['>= 1.34', '< 2.0.0']
   spec.add_runtime_dependency 'parallel'
   spec.add_runtime_dependency 'rspec'
+  spec.add_runtime_dependency 'honeycomb-beeline'
 end


### PR DESCRIPTION

![Screen Shot 2020-02-03 at 13 23 52](https://user-images.githubusercontent.com/20660680/73657626-8e985300-468a-11ea-8436-8fa3f45601c4.png)
Request for a review
Following changes with this PR
Pointed the gem to master(waiting for the release)
Add honeycomb-beeline gem to dependencies to litmus file
Updated code to capture modulename, travis/ appveyor information
Updated code to capture infm from run_bolt_task,bolt_run_script,bolt_upload_file,run_shell(for success and failure conditions)

Appveyor is not sending traces to the honeycomb (steps are different spec_prep then litmus:acceptance:parallel )