### PR TITLE
(MAINT) Add interpolate_powershell helper method

### DIFF
--- a/lib/puppet_litmus/util.rb
+++ b/lib/puppet_litmus/util.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Helper methods for testing puppet content
+module PuppetLitmus::Util
+  # Ensure that a passed command is base 64 encoded and passed to PowerShell; this obviates the need to
+  # carefully interpolate strings for passing to ruby which will then be passed to PowerShell/CMD which will
+  # then be executed. This also ensures that a single PowerShell command may be specified for Windows targets
+  # leveraging PowerShell as bolt run_shell will use PowerShell against a remote target but CMD against a
+  # localhost target.
+  #
+  # @param :command [String] A PowerShell script block to be converted to base64
+  # @return [String] An invocation for PowerShell with the encoded command which may be passed to run_shell
+  def self.interpolate_powershell(command)
+    encoded_command = Base64.strict_encode64(command.encode('UTF-16LE'))
+    "powershell.exe -NoProfile -EncodedCommand #{encoded_command}"
+  end
+end

--- a/spec/lib/puppet_litmus/util_spec.rb
+++ b/spec/lib/puppet_litmus/util_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+load File.expand_path('../../../lib/puppet_litmus/util.rb', __dir__)
+
+RSpec.describe PuppetLitmus::Util do
+  context 'when using interpolate_powershell' do
+    it 'interpolates the command' do
+      expect(described_class.interpolate_powershell('foo')).to match(%r{powershell\.exe})
+      expect(described_class.interpolate_powershell('foo')).to match(%r{NoProfile})
+      expect(described_class.interpolate_powershell('foo')).to match(%r{EncodedCommand})
+      expect(described_class.interpolate_powershell('foo')).not_to match(%r{foo})
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit running PowerShell commands against target hosts during an acceptance test run required that the author both:

1. Wrap any PowerShell commands to ensure that they would be executed both  locally and remotely in PowerShell, as bolt localhost execution does not  run in PowerShell by default, and
2. Manually verify the interpolation of the code to be executed, accounting for passing from ruby to bolt to powershell/cmd and possibly beyond.

This commit adds a helper method to be available during acceptance test runs which allows an author to pass a string for the scriptblock they want to run in PowerShell; whatever that string evaluates to will be executed.

It does this first by base-64 encoding the command, enabling the use of the `EncodedCommand` flag when invoking PowerShell.exe, which it then proceeds to do.