### PR TITLE
Improve rake task install_module and install_modules_from_directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,20 @@ jobs:
     services: docker
     before_script:
     - |
+      set -e
       git clone https://github.com/puppetlabs/puppetlabs-motd puppetlabs-motd
       cd puppetlabs-motd
       git reset --hard 88a0015287b943d448271f11b9d6ddc859ba5eca
       echo "gem 'puppet_litmus', require: false, git: 'https://github.com/${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}', branch: '${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}'" >> Gemfile
-      bundle install --with development --path vendor/bundle --gemfile=./Gemfile
-      BUNDLE_GEMFILE=./Gemfile bundle exec rake 'litmus:provision_list[default]'
-      BUNDLE_GEMFILE=./Gemfile bundle exec rake 'litmus:install_agent'
-      BUNDLE_GEMFILE=./Gemfile bundle exec rake 'litmus:install_module'
-      BUNDLE_GEMFILE=./Gemfile bundle exec rake 'litmus:add_feature[test_123]'
+      # override travis' defaults
+      unset BUNDLE_GEMFILE
+      bundle config set gemfile ./Gemfile
+      bundle config set path '../vendor/bundle'
+      bundle config set with development
+      bundle install
+      bundle exec rake 'litmus:provision_list[default]'
+      bundle exec rake 'litmus:install_agent'
+      bundle exec rake 'litmus:install_module'
+      bundle exec rake 'litmus:add_feature[test_123]'
     script:
-    - BUNDLE_GEMFILE=./Gemfile bundle exec rake litmus:acceptance:parallel
+    - bundle exec rake litmus:acceptance:parallel

--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -103,31 +103,6 @@ module PuppetLitmus::RakeHelper
     end
   end
 
-  # Builds all the modules in a specified module
-  #
-  # @param source_folder [String] the folder to get the modules from
-  # @return [Array] an array of module tar's
-  def build_modules_in_folder(source_folder)
-    folder_list = Dir.entries(source_folder).reject { |f| File.directory? f }
-    module_tars = []
-
-    target_dir = File.join(Dir.pwd, 'pkg')
-    # remove old build folder if exists, before we build afresh
-    FileUtils.rm_rf(target_dir) if File.directory?(target_dir)
-
-    folder_list.each do |folder|
-      folder_handle = Dir.open(File.join(source_folder, folder))
-      next if File.symlink?(folder_handle)
-
-      module_dir = folder_handle.path
-
-      # build_module
-      module_tar = build_module(module_dir, target_dir)
-      module_tars.push(File.new(module_tar))
-    end
-    module_tars
-  end
-
   def provision(provisioner, platform, inventory_vars)
     require 'bolt_spec/run'
     include BoltSpec::Run
@@ -268,6 +243,31 @@ module PuppetLitmus::RakeHelper
 
       run_command(install_module_command, target_nodes, config: nil, inventory: inventory_hash)
     end
+  end
+
+  # Builds all the modules in a specified module
+  #
+  # @param source_folder [String] the folder to get the modules from
+  # @return [Array] an array of module tar's
+  def build_modules_in_folder(source_folder)
+    folder_list = Dir.entries(source_folder).reject { |f| File.directory? f }
+    module_tars = []
+
+    target_dir = File.join(Dir.pwd, 'pkg')
+    # remove old build folder if exists, before we build afresh
+    FileUtils.rm_rf(target_dir) if File.directory?(target_dir)
+
+    folder_list.each do |folder|
+      folder_handle = Dir.open(File.join(source_folder, folder))
+      next if File.symlink?(folder_handle)
+
+      module_dir = folder_handle.path
+
+      # build_module
+      module_tar = build_module(module_dir, target_dir)
+      module_tars.push(File.new(module_tar))
+    end
+    module_tars
   end
 
   def metadata_module_name

--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bolt_spec/run'
 require 'honeycomb-beeline'
 Honeycomb.configure do |config|
   # override client if no configuration is provided, so that the pesky libhoney warning about lack of configuration is not shown
@@ -102,8 +103,7 @@ module PuppetLitmus::RakeHelper
   end
 
   def provision(provisioner, platform, inventory_vars)
-    require 'bolt_spec/run'
-    include BoltSpec::Run
+    include ::BoltSpec::Run
     raise "the provision module was not found in #{DEFAULT_CONFIG_DATA['modulepath']}, please amend the .fixtures.yml file" unless
       File.directory?(File.join(DEFAULT_CONFIG_DATA['modulepath'], 'provision'))
 
@@ -144,8 +144,7 @@ module PuppetLitmus::RakeHelper
       ENV['HTTP_X_HONEYCOMB_TRACE'] = span.to_trace_header unless ENV['HTTP_X_HONEYCOMB_TRACE']
       span.add_field('litmus.targets', targets)
 
-      require 'bolt_spec/run'
-      include BoltSpec::Run
+      include ::BoltSpec::Run
       config_data = { 'modulepath' => File.join(Dir.pwd, 'spec', 'fixtures', 'modules') }
       raise "the provision module was not found in #{config_data['modulepath']}, please amend the .fixtures.yml file" unless File.directory?(File.join(config_data['modulepath'], 'provision'))
 
@@ -180,8 +179,7 @@ module PuppetLitmus::RakeHelper
       span.add_field('litmus.collection', collection)
       span.add_field('litmus.targets', targets)
 
-      require 'bolt_spec/run'
-      include BoltSpec::Run
+      include ::BoltSpec::Run
       params = if collection.nil?
                  {}
                else
@@ -229,7 +227,7 @@ module PuppetLitmus::RakeHelper
       span.add_field('litmus.target_node_name', target_node_name)
       span.add_field('litmus.module_tar', module_tar)
 
-      include BoltSpec::Run
+      include ::BoltSpec::Run
 
       target_nodes = find_targets(inventory_hash, target_node_name)
       span.add_field('litmus.target_nodes', target_nodes)
@@ -278,8 +276,7 @@ module PuppetLitmus::RakeHelper
   end
 
   def uninstall_module(inventory_hash, target_node_name, module_to_remove = nil)
-    require 'bolt_spec/run'
-    include BoltSpec::Run
+    include ::BoltSpec::Run
     module_name = module_to_remove || metadata_module_name
     target_nodes = find_targets(inventory_hash, target_node_name)
     install_module_command = "puppet module uninstall #{module_name}"
@@ -295,8 +292,7 @@ module PuppetLitmus::RakeHelper
         PuppetLitmus::HoneycombUtils.add_platform_field(inventory_hash, target_node_name)
       end
 
-      require 'bolt_spec/run'
-      include BoltSpec::Run
+      include ::BoltSpec::Run
       target_nodes = find_targets(inventory_hash, target_node_name)
       results = run_command('cd .', target_nodes, config: nil, inventory: inventory_hash)
       span.add_field('litmus.bolt_result', results)

--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -233,13 +233,13 @@ module PuppetLitmus::RakeHelper
 
       target_nodes = find_targets(inventory_hash, target_node_name)
       span.add_field('litmus.target_nodes', target_nodes)
-      bolt_result = upload_file(module_tar, "/tmp/#{File.basename(module_tar)}", target_nodes, options: {}, config: nil, inventory: inventory_hash)
+      bolt_result = upload_file(module_tar, "/tmp/#{File.basename(module_tar)}", target_nodes, options: {}, config: nil, inventory: inventory_hash.clone)
       raise_bolt_errors(bolt_result, 'Failed to upload module.')
 
       install_module_command = "puppet module install --module_repository #{module_repository} /tmp/#{File.basename(module_tar)}"
       span.add_field('litmus.install_module_command', install_module_command)
 
-      bolt_result = run_command(install_module_command, target_nodes, config: nil, inventory: inventory_hash)
+      bolt_result = run_command(install_module_command, target_nodes, config: nil, inventory: inventory_hash.clone)
       raise_bolt_errors(bolt_result, "Installation of package #{module_tar} failed.")
       bolt_result
     end

--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-module PuppetLitmus; end # rubocop:disable Style/Documentation
-
 require 'honeycomb-beeline'
 Honeycomb.configure do |config|
   # override client if no configuration is provided, so that the pesky libhoney warning about lack of configuration is not shown
@@ -340,5 +338,19 @@ module PuppetLitmus::RakeHelper
       errors[target] = error_msg
     end
     errors
+  end
+
+  # Parse out errors messages in result set returned by Bolt command. If there are errors, raise them.
+  #
+  # @param result_set [Array] result set returned by Bolt command.
+  # @param error_msg [String] error message to raise when errors are detected. The actual errors will be appended.
+  def raise_bolt_errors(result_set, error_msg)
+    errors = check_bolt_errors(result_set)
+
+    unless errors.empty?
+      raise "#{error_msg}\nErrors: #{errors}"
+    end
+
+    nil
   end
 end

--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -236,7 +236,7 @@ module PuppetLitmus::RakeHelper
       bolt_result = upload_file(module_tar, "/tmp/#{File.basename(module_tar)}", target_nodes, options: {}, config: nil, inventory: inventory_hash.clone)
       raise_bolt_errors(bolt_result, 'Failed to upload module.')
 
-      install_module_command = "puppet module install --module_repository #{module_repository} /tmp/#{File.basename(module_tar)}"
+      install_module_command = "puppet module install --module_repository '#{module_repository}' /tmp/#{File.basename(module_tar)}"
       span.add_field('litmus.install_module_command', install_module_command)
 
       bolt_result = run_command(install_module_command, target_nodes, config: nil, inventory: inventory_hash.clone)

--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -231,12 +231,7 @@ namespace :litmus do
     # module_tar = Dir.glob('pkg/*.tar.gz').max_by { |f| File.mtime(f) }
     raise "Unable to find package in 'pkg/*.tar.gz'" if module_tar.nil?
 
-    result = install_module(inventory_hash, args[:target_node_name], module_tar, args[:module_repository])
-    raise_bolt_errors(result, "Installation of package #{module_tar} failed.")
-
-    result.each do |node|
-      puts "#{node['node']} failed #{node['result']}" if node['status'] != 'success'
-    end
+    install_module(inventory_hash, args[:target_node_name], module_tar, args[:module_repository])
 
     puts 'Installed'
   end

--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -232,8 +232,7 @@ namespace :litmus do
     raise "Unable to find package in 'pkg/*.tar.gz'" if module_tar.nil?
 
     result = install_module(inventory_hash, args[:target_node_name], module_tar, args[:module_repository])
-
-    raise "Failed trying to run 'puppet module install /tmp/#{File.basename(module_tar)}' against inventory." unless result.is_a?(Array)
+    raise_bolt_errors(result, "Installation of package #{module_tar} failed.")
 
     result.each do |node|
       puts "#{node['node']} failed #{node['result']}" if node['status'] != 'success'

--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -186,35 +186,15 @@ namespace :litmus do
                     end
     raise "Source folder doesnt exist #{source_folder}" unless File.directory?(source_folder)
 
+    puts 'Building'
     module_tars = build_modules_in_folder(source_folder)
     require 'bolt_spec/run'
     include BoltSpec::Run
-    puts '\nInstalling'
+    puts "\nInstalling"
     module_tars.each do |module_tar|
-      module_name = File.basename(module_tar)
-      local_path = module_tar.path.to_s
-      remote_path = "/tmp/#{module_name}"
-      puts "uploading and installing module #{module_name} to #{remote_path} on target(s) #{target_nodes}"
-      # upload module
-      upload_result = upload_file(
-        local_path,
-        remote_path,
-        target_nodes,
-        options: {},
-        config: nil,
-        inventory: inventory_hash,
-      )
-      # look for errors in result
-      upload_errors = check_bolt_errors(upload_result)
-      # let's report errors
-      unless upload_errors.empty?
-        raise "Upload of package #{module_name} failed. Errors per target: #{upload_errors}"
+      target_nodes.each do |target_node_name|
+        install_module(inventory_hash, target_node_name, module_tar, args[:module_repository])
       end
-
-      # install_module
-      install_module_command = "puppet module install --module_repository #{args[:module_repository]} --force /tmp/#{File.basename(module_tar)}"
-      run_command(install_module_command, target_nodes, config: nil, inventory: inventory_hash)
-      print "#{File.basename(module_tar)} "
     end
   end
 

--- a/spec/lib/puppet_litmus/rake_helper_spec.rb
+++ b/spec/lib/puppet_litmus/rake_helper_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe PuppetLitmus::RakeHelper do
     end
     let(:module_tar) { '/tmp/foo.tar.gz' }
     let(:targets) { ['some.host'] }
-    let(:install_module_command) { "puppet module install --module_repository https://forgeapi.puppetlabs.com #{module_tar}" }
+    let(:install_module_command) { "puppet module install --module_repository 'https://forgeapi.puppetlabs.com' #{module_tar}" }
 
     it 'calls function' do
       allow_any_instance_of(BoltSpec::Run).to receive(:upload_file).with(module_tar, module_tar, targets, options: {}, config: nil, inventory: inventory_hash).and_return([])

--- a/spec/lib/puppet_litmus/rake_helper_spec.rb
+++ b/spec/lib/puppet_litmus/rake_helper_spec.rb
@@ -102,11 +102,10 @@ RSpec.describe PuppetLitmus::RakeHelper do
     end
     let(:module_tar) { '/tmp/foo.tar.gz' }
     let(:targets) { ['some.host'] }
-    let(:install_module_command) { "puppet module install --module_repository https://forgeapi.puppetlabs.com /tmp/#{File.basename(module_tar)}" }
+    let(:install_module_command) { "puppet module install --module_repository https://forgeapi.puppetlabs.com #{module_tar}" }
 
     it 'calls function' do
-      allow(Open3).to receive(:capture3).with("bundle exec bolt file upload \"#{module_tar}\" /tmp/#{File.basename(module_tar)} --nodes all --inventoryfile inventory.yaml")
-                                        .and_return(['success', '', 0])
+      allow_any_instance_of(BoltSpec::Run).to receive(:upload_file).with(module_tar, module_tar, targets, options: {}, config: nil, inventory: inventory_hash).and_return([])
       allow_any_instance_of(BoltSpec::Run).to receive(:run_command).with(install_module_command, targets, config: nil, inventory: inventory_hash).and_return([])
       described_class.install_module(inventory_hash, nil, module_tar)
     end

--- a/spec/lib/puppet_litmus/rake_tasks_spec.rb
+++ b/spec/lib/puppet_litmus/rake_tasks_spec.rb
@@ -37,8 +37,7 @@ describe 'litmus rake tasks' do
       expect(File).to receive(:directory?).with(target_folder).and_return(true)
       expect_any_instance_of(Object).to receive(:build_modules_in_folder).with(target_folder).and_return([dummy_tar])
       expect(STDOUT).to receive(:puts).with('Building')
-      expect(STDOUT).to receive(:puts).with("\nSending")
-      expect_any_instance_of(Object).to receive(:upload_file).once
+      expect_any_instance_of(Object).to receive(:upload_file).once.and_return([])
       expect(STDOUT).to receive(:puts).with("\nInstalling")
       expect_any_instance_of(Object).to receive(:run_command).once
       Rake::Task['litmus:install_modules_from_directory'].invoke('./spec/fixtures/modules')

--- a/spec/lib/puppet_litmus/rake_tasks_spec.rb
+++ b/spec/lib/puppet_litmus/rake_tasks_spec.rb
@@ -39,7 +39,7 @@ describe 'litmus rake tasks' do
       expect(STDOUT).to receive(:puts).with('Building')
       expect_any_instance_of(Object).to receive(:upload_file).once.and_return([])
       expect(STDOUT).to receive(:puts).with("\nInstalling")
-      expect_any_instance_of(Object).to receive(:run_command).once
+      expect_any_instance_of(Object).to receive(:run_command).once.and_return([])
       Rake::Task['litmus:install_modules_from_directory'].invoke('./spec/fixtures/modules')
     end
   end


### PR DESCRIPTION
Fixes #246, fixes #270, fixes #250.

Core bits are the moving of the `target_dir` clean up in `build_modules_in_folder` and the general cleanup by re-using `build_module`, `upload_file` and `install_module` instead of duplicating the implementations.