### PR TITLE
(GH-246) Fix install_modules_from_directory logic

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -122,11 +122,6 @@ Lint/NestedMethodDefinition:
 RSpec/MessageSpies:
   Enabled: false
 
-# If neighbouring parameters are both hashes, it helps to have braces round both.
-Style/BracesAroundHashParameters:
-  Exclude:
-    - 'spec/puppet/resource_api/base_context_spec.rb'
-
 # requires 2.3's squiggly HEREDOC support, which we can't use, yet
 # see http://www.virtuouscode.com/2016/01/06/about-the-ruby-squiggly-heredoc-syntax/
 Layout/HeredocIndentation:

--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -68,15 +68,15 @@ module PuppetLitmus::RakeHelper
     folder_list = Dir.entries(source_folder).reject { |f| File.directory? f }
     module_tars = []
     folder_list.each do |folder|
-      file = File.new(File.join(source_folder, folder))
-      next if File.symlink?(file)
+      folder_handle = Dir.open(File.join(source_folder, folder))
+      next if File.symlink?(folder_handle)
 
       opts = {}
-      opts[:module_dir] = file.path
+      opts[:module_dir] = folder_handle.path
       opts[:'target-dir'] = File.join(Dir.pwd, 'pkg')
       opts[:force] = true
       # remove old build folder if exists, before we build afresh
-      FileUtils.rm_rf(builder.build_dir) if File.directory?(builder.build_dir)
+      FileUtils.rm_rf(opts[:'target-dir']) if File.directory?(opts[:'target-dir'])
 
       # build_module
       module_tar = build_module(opts)


### PR DESCRIPTION
Prior to this commit the `install_modules_from_directory` method failed on Windows nodes when calling `File.new` on a folder; this commit modifies the logic to instead grab the folder handle by `Dir.open` and use that instead.

The logic in the same method for deleting the build folder erroneously specified the builder instance which, at this point in the execution, has not been instantiated yet. This commit also modifies that logic to delete the target directory, which is where the built module tars are placed.

These fixes support but do not resolve #246 filed by @findmyname666, as the underlying problem around connections is caused by the removal of the version from the `inventory_hash` in `BoltSpec::Run`. For more information, see puppetlabs/bolt#1614.