### PR TITLE
Allow users to install modules form a private forge repository

### DIFF
--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -248,7 +248,7 @@ module PuppetLitmus::RakeHelper
     builder.build
   end
 
-  def install_module(inventory_hash, target_node_name, module_tar)
+  def install_module(inventory_hash, target_node_name, module_tar, module_repository = 'https://forgeapi.puppetlabs.com')
     require 'bolt_spec/run'
     include BoltSpec::Run
     target_nodes = find_targets(inventory_hash, target_node_name)
@@ -258,7 +258,7 @@ module PuppetLitmus::RakeHelper
                       target_node_name
                     end
     run_local_command("bundle exec bolt file upload \"#{module_tar}\" /tmp/#{File.basename(module_tar)} --nodes #{target_string} --inventoryfile inventory.yaml")
-    install_module_command = "puppet module install /tmp/#{File.basename(module_tar)}"
+    install_module_command = "puppet module install --module_repository #{module_repository} /tmp/#{File.basename(module_tar)}"
     Honeycomb.start_span(name: 'install_module') do |span|
       ENV['HTTP_X_HONEYCOMB_TRACE'] = span.to_trace_header unless ENV['HTTP_X_HONEYCOMB_TRACE']
       span.add_field('litmus.install_module_command', install_module_command)

--- a/spec/lib/puppet_litmus/rake_helper_spec.rb
+++ b/spec/lib/puppet_litmus/rake_helper_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe PuppetLitmus::RakeHelper do
     end
     let(:module_tar) { '/tmp/foo.tar.gz' }
     let(:targets) { ['some.host'] }
-    let(:install_module_command) { "puppet module install /tmp/#{File.basename(module_tar)}" }
+    let(:install_module_command) { "puppet module install --module_repository https://forgeapi.puppetlabs.com /tmp/#{File.basename(module_tar)}" }
 
     it 'calls function' do
       allow(Open3).to receive(:capture3).with("bundle exec bolt file upload \"#{module_tar}\" /tmp/#{File.basename(module_tar)} --nodes all --inventoryfile inventory.yaml")


### PR DESCRIPTION
Closes #259 

This change will allow the user to pass a private forge repository when running:

* rake install_module
* rake reinstall_module
* rake install_modules_form_directory
* rake provision_install