### PR TITLE
(maint) make sure that errors in the acceptance tests fail; fix code to actually pass

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,6 +55,7 @@ for:
         Get-Content Gemfile.lock
   test_script:
     - pwsh: |
+        $ErrorActionPreference = 'Stop'
         $ENV:PATH = "C:\Ruby${ENV:RUBY_VERSION}\bin;${ENV:PATH}"
         $ENV:BUNDLE_GEMFILE = './Gemfile'
         Push-Location motd
@@ -64,7 +65,9 @@ for:
         gem -v
         bundle -v
         bundle exec rake spec_prep
+        if(-not $?) { Write-Error -Message "spec_prep failed" }
         bundle exec rake litmus:acceptance:localhost
+        if(-not $?) { Write-Error -Message "litmus:acceptance:localhost failed" }
 matrix:
   fast_finish: true
 install:

--- a/lib/puppet_litmus/inventory_manipulation.rb
+++ b/lib/puppet_litmus/inventory_manipulation.rb
@@ -37,6 +37,7 @@ module PuppetLitmus::InventoryManipulation
               'uri' => 'litmus_localhost',
               'config' => { 'transport' => 'local' },
               'feature' => 'puppet-agent',
+              'facts' => { 'platform' => 'localhost' },
             },
           ],
         },


### PR DESCRIPTION
As it turned out PowerShell does not report errors from subcommands as errors by default.