### PR TITLE
(IAC-660) make the platform fact optional

### DIFF
--- a/lib/puppet_litmus.rb
+++ b/lib/puppet_litmus.rb
@@ -4,6 +4,7 @@
 module PuppetLitmus; end
 
 require 'bolt_spec/run'
+require 'puppet_litmus/honeycomb_utils'
 require 'puppet_litmus/inventory_manipulation'
 require 'puppet_litmus/puppet_helpers'
 require 'puppet_litmus/rake_helper'

--- a/lib/puppet_litmus/honeycomb_utils.rb
+++ b/lib/puppet_litmus/honeycomb_utils.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PuppetLitmus; end # rubocop:disable Style/Documentation
+
+# a set of semi-private utility functions that should not contaminate the global namespace
+module PuppetLitmus::HoneycombUtils
+  module_function
+
+  def add_platform_field(inventory_hash, target_node_name)
+    facts = facts_from_node(inventory_hash, target_node_name)
+    Honeycomb.current_span.add_field('litmus.platform', facts&.dig('platform'))
+  end
+end

--- a/lib/puppet_litmus/inventory_manipulation.rb
+++ b/lib/puppet_litmus/inventory_manipulation.rb
@@ -37,7 +37,6 @@ module PuppetLitmus::InventoryManipulation
               'uri' => 'litmus_localhost',
               'config' => { 'transport' => 'local' },
               'feature' => 'puppet-agent',
-              'facts' => { 'platform' => 'localhost' },
             },
           ],
         },

--- a/lib/puppet_litmus/puppet_helpers.rb
+++ b/lib/puppet_litmus/puppet_helpers.rb
@@ -70,7 +70,7 @@ module PuppetLitmus::PuppetHelpers
       raise "Target '#{target_node_name}' not found in inventory.yaml" unless target_in_inventory?(inventory_hash, target_node_name)
 
       span.add_field('litmus.node_name', target_node_name)
-      span.add_field('litmus.platform', facts_from_node(inventory_hash, target_node_name)['platform'])
+      PuppetLitmus::HoneycombUtils.add_platform_field(inventory_hash, target_node_name)
 
       command_to_run = "#{opts[:prefix_command]} puppet apply #{manifest_file_location}"
       command_to_run += " --modulepath #{Dir.pwd}/spec/fixtures/modules" if target_node_name == 'litmus_localhost'
@@ -129,7 +129,7 @@ module PuppetLitmus::PuppetHelpers
         # transfer to TARGET_HOST
         inventory_hash = inventory_hash_from_inventory_file
         span.add_field('litmus.node_name', target_node_name)
-        span.add_field('litmus.platform', facts_from_node(inventory_hash, target_node_name)['platform'])
+        PuppetLitmus::HoneycombUtils.add_platform_field(inventory_hash, target_node_name)
 
         manifest_file_location = "/tmp/#{File.basename(manifest_file)}"
         bolt_result = upload_file(manifest_file.path, manifest_file_location, target_node_name, options: {}, config: nil, inventory: inventory_hash)
@@ -160,7 +160,7 @@ module PuppetLitmus::PuppetHelpers
       raise "Target '#{target_node_name}' not found in inventory.yaml" unless target_in_inventory?(inventory_hash, target_node_name)
 
       span.add_field('litmus.node_name', target_node_name)
-      span.add_field('litmus.platform', facts_from_node(inventory_hash, target_node_name)['platform'])
+      PuppetLitmus::HoneycombUtils.add_platform_field(inventory_hash, target_node_name)
 
       bolt_result = run_command(command_to_run, target_node_name, config: nil, inventory: inventory_hash)
       span.add_field('litmus.bolt_result', bolt_result)
@@ -199,7 +199,7 @@ module PuppetLitmus::PuppetHelpers
       raise "Target '#{target_node_name}' not found in inventory.yaml" unless target_in_inventory?(inventory_hash, target_node_name)
 
       span.add_field('litmus.node_name', target_node_name)
-      span.add_field('litmus.platform', facts_from_node(inventory_hash, target_node_name)['platform'])
+      PuppetLitmus::HoneycombUtils.add_platform_field(inventory_hash, target_node_name)
 
       bolt_result = upload_file(source, destination, target_node_name, options: options, config: nil, inventory: inventory_hash)
       span.add_field('litmus.bolt_result', bolt_result)
@@ -257,7 +257,7 @@ module PuppetLitmus::PuppetHelpers
       raise "Target '#{target_node_name}' not found in inventory.yaml" unless target_in_inventory?(inventory_hash, target_node_name)
 
       span.add_field('litmus.node_name', target_node_name)
-      span.add_field('litmus.platform', facts_from_node(inventory_hash, target_node_name)['platform'])
+      PuppetLitmus::HoneycombUtils.add_platform_field(inventory_hash, target_node_name)
 
       bolt_result = run_task(task_name, target_node_name, params, config: config_data, inventory: inventory_hash)
       result_obj = {
@@ -318,7 +318,7 @@ module PuppetLitmus::PuppetHelpers
       raise "Target '#{target_node_name}' not found in inventory.yaml" unless target_in_inventory?(inventory_hash, target_node_name)
 
       span.add_field('litmus.node_name', target_node_name)
-      span.add_field('litmus.platform', facts_from_node(inventory_hash, target_node_name)['platform'])
+      PuppetLitmus::HoneycombUtils.add_platform_field(inventory_hash, target_node_name)
 
       bolt_result = run_script(script, target_node_name, arguments, options: opts, config: nil, inventory: inventory_hash)
 

--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -185,12 +185,12 @@ module PuppetLitmus::RakeHelper
     Honeycomb.start_span(name: 'litmus.tear_down') do |span|
       ENV['HTTP_X_HONEYCOMB_TRACE'] = span.to_trace_header unless ENV['HTTP_X_HONEYCOMB_TRACE']
       # how do we know what provisioner to use
-      node_facts = facts_from_node(inventory_hash, node_name)
 
       span.add_field('litmus.node_name', node_name)
-      span.add_field('litmus.platform', node_facts['platform'])
+      PuppetLitmus::HoneycombUtils.add_platform_field(inventory_hash, node_name)
 
       params = { 'action' => 'tear_down', 'node_name' => node_name, 'inventory' => Dir.pwd }
+      node_facts = facts_from_node(inventory_hash, node_name)
       run_task(provisioner_task(node_facts['provisioner']), 'localhost', params, config: DEFAULT_CONFIG_DATA, inventory: nil)
     end
   end
@@ -289,7 +289,7 @@ module PuppetLitmus::RakeHelper
       # if we're only checking connectivity for a single node
       if target_node_name
         span.add_field('litmus.node_name', target_node_name)
-        span.add_field('litmus.platform', facts_from_node(inventory_hash, target_node_name)['platform'])
+        PuppetLitmus::HoneycombUtils.add_platform_field(inventory_hash, target_node_name)
       end
 
       require 'bolt_spec/run'


### PR DESCRIPTION
Fixes #269, the use-case of supplying your own inventory.yaml without extra attached facts.

This also reverts the ugly addition to the `localhost_inventory_hash`, since that is not needed anymore.