### PR TITLE
Fix missing require in `litmus:tear_down`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,4 @@ jobs:
       bundle exec rake 'litmus:add_feature[test_123]'
     script:
     - bundle exec rake litmus:acceptance:parallel
+    - bundle exec rake litmus:tear_down

--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -2,6 +2,7 @@
 
 require 'bolt_spec/run'
 require 'honeycomb-beeline'
+require 'puppet_litmus/honeycomb_utils'
 Honeycomb.configure do |config|
   # override client if no configuration is provided, so that the pesky libhoney warning about lack of configuration is not shown
   unless ENV['HONEYCOMB_WRITEKEY'] && ENV['HONEYCOMB_DATASET']


### PR DESCRIPTION
Based on the work in #247 and a bug report in internal slack add testing for tear_down.