### PR TITLE
(IAC-187) force installing modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ jobs:
       bundle exec rake 'litmus:provision_list[default]'
       bundle exec rake 'litmus:install_agent'
       bundle exec rake 'litmus:install_module'
+      bundle exec rake 'litmus:install_module'
       bundle exec rake 'litmus:add_feature[test_123]'
     script:
     - bundle exec rake litmus:acceptance:parallel

--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -229,6 +229,10 @@ module PuppetLitmus::RakeHelper
       span.add_field('litmus.target_node_name', target_node_name)
       span.add_field('litmus.module_tar', module_tar)
 
+      # make sure the target module is not installed
+      # otherwise `puppet module install` might silently skip it
+      uninstall_module(inventory_hash.clone, target_node_name, force: true)
+
       include ::BoltSpec::Run
 
       target_nodes = find_targets(inventory_hash, target_node_name)
@@ -280,11 +284,12 @@ module PuppetLitmus::RakeHelper
     metadata['name']
   end
 
-  def uninstall_module(inventory_hash, target_node_name, module_to_remove = nil)
+  def uninstall_module(inventory_hash, target_node_name, module_to_remove = nil, **opts)
     include ::BoltSpec::Run
     module_name = module_to_remove || metadata_module_name
     target_nodes = find_targets(inventory_hash, target_node_name)
     install_module_command = "puppet module uninstall #{module_name}"
+    install_module_command += ' --force' if opts[:force]
     run_command(install_module_command, target_nodes, config: nil, inventory: inventory_hash)
   end
 

--- a/spec/lib/puppet_litmus/rake_helper_spec.rb
+++ b/spec/lib/puppet_litmus/rake_helper_spec.rb
@@ -102,10 +102,16 @@ RSpec.describe PuppetLitmus::RakeHelper do
     end
     let(:module_tar) { '/tmp/foo.tar.gz' }
     let(:targets) { ['some.host'] }
+    let(:uninstall_module_command) { 'puppet module uninstall foo --force' }
     let(:install_module_command) { "puppet module install --module_repository 'https://forgeapi.puppetlabs.com' #{module_tar}" }
 
     it 'calls function' do
       allow_any_instance_of(BoltSpec::Run).to receive(:upload_file).with(module_tar, module_tar, targets, options: {}, config: nil, inventory: inventory_hash).and_return([])
+      allow(File).to receive(:exist?).with(File.join(Dir.pwd, 'metadata.json')).and_return(true)
+      allow(File).to receive(:read).with(File.join(Dir.pwd, 'metadata.json')).and_return(JSON.dump({ name: 'foo' }))
+      allow(Open3).to receive(:capture3).with("bundle exec bolt file upload \"#{module_tar}\" /tmp/#{File.basename(module_tar)} --nodes all --inventoryfile inventory.yaml")
+                                        .and_return(['success', '', 0])
+      allow_any_instance_of(BoltSpec::Run).to receive(:run_command).with(uninstall_module_command, targets, config: nil, inventory: inventory_hash).and_return([])
       allow_any_instance_of(BoltSpec::Run).to receive(:run_command).with(install_module_command, targets, config: nil, inventory: inventory_hash).and_return([])
       described_class.install_module(inventory_hash, nil, module_tar)
     end

--- a/spec/lib/puppet_litmus/rake_tasks_spec.rb
+++ b/spec/lib/puppet_litmus/rake_tasks_spec.rb
@@ -32,6 +32,9 @@ describe 'litmus rake tasks' do
     let(:dummy_tar) { File.new('spec/data/doot.tar.gz') }
 
     it 'happy path' do
+      allow(File).to receive(:exist?).with(File.join(Dir.pwd, 'metadata.json')).and_return(true)
+      allow(File).to receive(:read).with(File.join(Dir.pwd, 'metadata.json')).and_return(JSON.dump({ name: 'foo' }))
+
       stub_const('ENV', ENV.to_hash.merge('TARGET_HOST' => 'some.host'))
       expect_any_instance_of(PuppetLitmus::InventoryManipulation).to receive(:inventory_hash_from_inventory_file).and_return(inventory_hash)
       expect(File).to receive(:directory?).with(target_folder).and_return(true)
@@ -39,7 +42,7 @@ describe 'litmus rake tasks' do
       expect(STDOUT).to receive(:puts).with('Building')
       expect_any_instance_of(Object).to receive(:upload_file).once.and_return([])
       expect(STDOUT).to receive(:puts).with("\nInstalling")
-      expect_any_instance_of(Object).to receive(:run_command).once.and_return([])
+      expect_any_instance_of(Object).to receive(:run_command).twice.and_return([])
       Rake::Task['litmus:install_modules_from_directory'].invoke('./spec/fixtures/modules')
     end
   end


### PR DESCRIPTION
This makes `litmus:install_module` much safer as it ensures that it actually updates the module on the target systems. Previously it would have just failed quietly.