### PR TITLE
Use 'target' instead of 'node' in bolt result hashes

### DIFF
--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -57,7 +57,7 @@ namespace :litmus do
       end
 
       if result.first['status'] != 'success'
-        failed_image_message += "=====\n#{result.first['node']}\n#{result.first['value']['_output']}\n#{result.inspect}"
+        failed_image_message += "=====\n#{result.first['target']}\n#{result.first['value']['_output']}\n#{result.inspect}"
       else
         STDOUT.puts "#{result.first['value']['node_name']}, #{image}"
       end
@@ -119,11 +119,11 @@ namespace :litmus do
     results = install_agent(args[:collection], targets, inventory_hash)
     results.each do |result|
       if result['status'] != 'success'
-        command_to_run = "bolt task run puppet_agent::install --targets #{result['node']} --inventoryfile inventory.yaml --modulepath #{DEFAULT_CONFIG_DATA['modulepath']}"
-        raise "Failed on #{result['node']}\n#{result}\ntry running '#{command_to_run}'"
+        command_to_run = "bolt task run puppet_agent::install --targets #{result['target']} --inventoryfile inventory.yaml --modulepath #{DEFAULT_CONFIG_DATA['modulepath']}"
+        raise "Failed on #{result['target']}\n#{result}\ntry running '#{command_to_run}'"
       else
         # add puppet-agent feature to successful nodes
-        inventory_hash = add_feature_to_node(inventory_hash, 'puppet-agent', result['node'])
+        inventory_hash = add_feature_to_node(inventory_hash, 'puppet-agent', result['target'])
       end
     end
     # update the inventory with the puppet-agent feature set per node
@@ -134,7 +134,7 @@ namespace :litmus do
 
     results.each do |result|
       if result['status'] != 'success'
-        puts "Failed on #{result['node']}\n#{result}"
+        puts "Failed on #{result['target']}\n#{result}"
       end
     end
   end
@@ -296,7 +296,7 @@ namespace :litmus do
     raise "Failed trying to run 'puppet module uninstall #{module_name}' against inventory." unless result.is_a?(Array)
 
     result.each do |node|
-      puts "#{node['node']} failed #{node['value']}" if node['status'] != 'success'
+      puts "#{node['target']} failed #{node['value']}" if node['status'] != 'success'
     end
 
     puts 'Uninstalled'

--- a/spec/lib/puppet_litmus/puppet_helpers_spec.rb
+++ b/spec/lib/puppet_litmus/puppet_helpers_spec.rb
@@ -120,8 +120,8 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
     let(:remote) { '/remote_tmp' }
     # Ignore rubocop because these hashes are representative of output from an external method and editing them leads to test failures.
     # rubocop:disable Layout/SpaceInsideHashLiteralBraces, Layout/SpaceInsideBlockBraces, Layout/SpaceAroundOperators, Layout/LineLength, Layout/SpaceAfterComma
-    let(:result_success) {[{'node'=>'some.host','target'=>'some.host','action'=>'upload','object'=>'C:\foo\bar.ps1','status'=>'success','value'=>{'_output'=>'Uploaded \'C:\foo\bar.ps1\' to \'some.host:C:\bar\''}}]}
-    let(:result_failure) {[{'node'=>'some.host','target'=>'some.host','action'=>nil,'object'=>nil,'status'=>'failure','value'=>{'_error'=>{'kind'=>'puppetlabs.tasks/task_file_error','msg'=>'No such file or directory @ rb_sysopen - /nonexistant/file/path','details'=>{},'issue_code'=>'WRITE_ERROR'}}}]}
+    let(:result_success) {[{'target'=>'some.host','action'=>'upload','object'=>'C:\foo\bar.ps1','status'=>'success','value'=>{'_output'=>'Uploaded \'C:\foo\bar.ps1\' to \'some.host:C:\bar\''}}]}
+    let(:result_failure) {[{'target'=>'some.host','action'=>nil,'object'=>nil,'status'=>'failure','value'=>{'_error'=>{'kind'=>'puppetlabs.tasks/task_file_error','msg'=>'No such file or directory @ rb_sysopen - /nonexistant/file/path','details'=>{},'issue_code'=>'WRITE_ERROR'}}}]}
     # rubocop:enable Layout/SpaceInsideHashLiteralBraces, Layout/SpaceInsideBlockBraces, Layout/SpaceAroundOperators, Layout/LineLength, Layout/SpaceAfterComma
 
     it 'responds to run_shell' do
@@ -222,9 +222,9 @@ RSpec.describe PuppetLitmus::PuppetHelpers do
     let(:config_data) { { 'modulepath' => File.join(Dir.pwd, 'spec', 'fixtures', 'modules') } }
     # Ignore rubocop because these hashes are representative of output from an external method and editing them leads to test failures.
     # rubocop:disable Layout/SpaceInsideHashLiteralBraces, Layout/SpaceBeforeBlockBraces, Layout/SpaceInsideBlockBraces, Layout/SpaceAroundOperators, Layout/LineLength, Layout/SpaceAfterComma
-    let(:result_unstructured_task_success){ [{'node'=>'some.host','target'=>'some.host','action'=>'task','object'=>'testtask::unstructured','status'=>'success','value'=>{'_output'=>'SUCCESS!'}}]}
-    let(:result_structured_task_success){ [{'node'=>'some.host','target'=>'some.host','action'=>'task','object'=>'testtask::structured','status'=>'success','value'=>{'key1'=>'foo','key2'=>'bar'}}]}
-    let(:result_failure) {[{'node'=>'some.host','target'=>'some.host','action'=>'task','object'=>'testtask::unstructured','status'=>'failure','value'=>{'_error'=>{'msg'=>'FAILURE!','kind'=>'puppetlabs.tasks/task-error','details'=>{'exitcode'=>123}}}}]}
+    let(:result_unstructured_task_success){ [{'target'=>'some.host','action'=>'task','object'=>'testtask::unstructured','status'=>'success','value'=>{'_output'=>'SUCCESS!'}}]}
+    let(:result_structured_task_success){ [{'target'=>'some.host','action'=>'task','object'=>'testtask::structured','status'=>'success','value'=>{'key1'=>'foo','key2'=>'bar'}}]}
+    let(:result_failure) {[{'target'=>'some.host','action'=>'task','object'=>'testtask::unstructured','status'=>'failure','value'=>{'_error'=>{'msg'=>'FAILURE!','kind'=>'puppetlabs.tasks/task-error','details'=>{'exitcode'=>123}}}}]}
     # rubocop:enable Layout/SpaceInsideHashLiteralBraces, Layout/SpaceBeforeBlockBraces, Layout/SpaceInsideBlockBraces, Layout/SpaceAroundOperators, Layout/LineLength, Layout/SpaceAfterComma
 
     it 'responds to bolt_run_task' do

--- a/spec/lib/puppet_litmus/rake_tasks_spec.rb
+++ b/spec/lib/puppet_litmus/rake_tasks_spec.rb
@@ -59,8 +59,7 @@ describe 'litmus rake tasks' do
 
   context 'with litmus:provision task' do
     it 'happy path' do
-      results = [{ 'node' => 'localhost',
-                   'target' => 'localhost',
+      results = [{ 'target' => 'localhost',
                    'action' => 'task',
                    'object' => 'provision::docker',
                    'status' => 'success',


### PR DESCRIPTION
At some points we were still using bolt v1 hash keys and were not accessing
the correct information. This changes all uses of `'node'` to `'target'`
to address this.