### PR TITLE
Log the filename instead of the file object when install fails

### DIFF
--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -247,7 +247,7 @@ module PuppetLitmus::RakeHelper
       span.add_field('litmus.install_module_command', install_module_command)
 
       bolt_result = run_command(install_module_command, target_nodes, config: nil, inventory: inventory_hash.clone)
-      raise_bolt_errors(bolt_result, "Installation of package #{module_tar} failed.")
+      raise_bolt_errors(bolt_result, "Installation of package #{File.basename(module_tar)} failed.")
       bolt_result
     end
   end


### PR DESCRIPTION
Fixes #295 

Minor fix to the error message that is emitted when `puppet module install` fails

Before:
```
$ pdk bundle exec rake litmus:install_modules_from_directory
pdk (INFO): Using Ruby 2.5.8
pdk (INFO): Using Puppet 6.15.0
Building

Installing
rake aborted!
Installation of package #<File:0x00007fe30f31cb40> failed.
Errors: {"localhost:2222"=>"The command failed with exit code 1"}
```

After:
```
$ pdk bundle exec rake litmus:install_modules_from_directory
pdk (INFO): Using Ruby 2.5.8
pdk (INFO): Using Puppet 6.15.0
Building

Installing
rake aborted!
Installation of package puppetlabs-facts-1.0.0.tar.gz failed.
Errors: {"localhost:2222"=>"The command failed with exit code 1"}
```