### PR TITLE
Use default working directory for all uploads to SUTs

### DIFF
--- a/lib/puppet_litmus/puppet_helpers.rb
+++ b/lib/puppet_litmus/puppet_helpers.rb
@@ -135,7 +135,7 @@ module PuppetLitmus::PuppetHelpers
         span.add_field('litmus.node_name', target_node_name)
         add_platform_field(inventory_hash, target_node_name)
 
-        manifest_file_location = "/tmp/#{File.basename(manifest_file)}"
+        manifest_file_location = File.basename(manifest_file)
         bolt_result = upload_file(manifest_file.path, manifest_file_location, target_node_name, options: {}, config: nil, inventory: inventory_hash)
         span.add_field('litmus.bolt_result', bolt_result)
         raise bolt_result.first['value'].to_s unless bolt_result.first['status'] == 'success'

--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -240,10 +240,10 @@ module PuppetLitmus::RakeHelper
 
       target_nodes = find_targets(inventory_hash, target_node_name)
       span.add_field('litmus.target_nodes', target_nodes)
-      bolt_result = upload_file(module_tar, "/tmp/#{File.basename(module_tar)}", target_nodes, options: {}, config: nil, inventory: inventory_hash.clone)
+      bolt_result = upload_file(module_tar, File.basename(module_tar), target_nodes, options: {}, config: nil, inventory: inventory_hash.clone)
       raise_bolt_errors(bolt_result, 'Failed to upload module.')
 
-      install_module_command = "puppet module install --module_repository '#{module_repository}' /tmp/#{File.basename(module_tar)}"
+      install_module_command = "puppet module install --module_repository '#{module_repository}' #{File.basename(module_tar)}"
       span.add_field('litmus.install_module_command', install_module_command)
 
       bolt_result = run_command(install_module_command, target_nodes, config: nil, inventory: inventory_hash.clone)

--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -335,7 +335,7 @@ module PuppetLitmus::RakeHelper
   # Parse out errors messages in result set returned by Bolt command.
   #
   # @param result_set [Array] result set returned by Bolt command.
-  # @return [Hash] Error messages grouped by target.
+  # @return [Hash] Errors grouped by target.
   def check_bolt_errors(result_set)
     errors = {}
     # iterate through each error
@@ -346,8 +346,7 @@ module PuppetLitmus::RakeHelper
 
       target = target_result['target']
       # get some info from error
-      error_msg = target_result['value']['_error']['msg']
-      errors[target] = error_msg
+      errors[target] = target_result['value']['_error']
     end
     errors
   end


### PR DESCRIPTION
Using `/tmp` as upload target meant that `install_module` and
`create_manifest_file` would not work with windows SUTs, which do
not have that directory.

This changes those methods to not use any directory, dumping files
into the default user's home directory instead.

Fixes: #249