### PR TITLE
(IAC-825) - Adding net-ssh 5 dependent gems

### DIFF
--- a/puppet_litmus.gemspec
+++ b/puppet_litmus.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rspec'
   spec.add_runtime_dependency 'honeycomb-beeline'
   spec.add_runtime_dependency 'rspec_honeycomb_formatter'
+  spec.add_runtime_dependency 'ed25519', ['>= 1.2', '< 2.0']
+  spec.add_runtime_dependency 'bcrypt_pbkdf', ['>= 1.0', '< 2.0']
 end


### PR DESCRIPTION
Placing net-ssh 5 dependent gems into the gemspec. This means they are added in 1 place rather than in all modules.