### PR TITLE
(IAC-896) Release Prep 0.18.4 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v0.18.4](https://github.com/puppetlabs/puppet_litmus/tree/v0.18.4) (2020-07-01)
+
+[Full Changelog](https://github.com/puppetlabs/puppet_litmus/compare/v0.18.3...v0.18.4)
+
+### Fixed
+
+- \(IAC-896\) - Revert "\(IAC-825\) - Adding net-ssh 5 dependent gems" [\#313](https://github.com/puppetlabs/puppet_litmus/pull/313) ([pmcmaw](https://github.com/pmcmaw))
+- Protect version reporting from undefined-ness [\#312](https://github.com/puppetlabs/puppet_litmus/pull/312) ([DavidS](https://github.com/DavidS))
+- Ignore stderr of serverspec commands by setting request\_pty to false [\#309](https://github.com/puppetlabs/puppet_litmus/pull/309) ([lswith](https://github.com/lswith))
+
 ## [v0.18.3](https://github.com/puppetlabs/puppet_litmus/tree/v0.18.3) (2020-06-10)
 
 [Full Changelog](https://github.com/puppetlabs/puppet_litmus/compare/v0.18.2...v0.18.3)

--- a/lib/puppet_litmus/version.rb
+++ b/lib/puppet_litmus/version.rb
@@ -2,5 +2,5 @@
 
 # version of this gem
 module PuppetLitmus
-  VERSION ||= '0.18.3'
+  VERSION ||= '0.18.4'
 end


### PR DESCRIPTION
Tests
https://github.com/puppetlabs/puppetlabs-motd/pull/317
https://github.com/puppetlabs/puppetlabs-package/pull/204
https://github.com/puppetlabs/puppetlabs-scheduled_task/pull/143

ReleaseChecks
`Finished in 4 minutes 19.6 seconds (files took 13.07 seconds to load)
8 examples, 0 failures


pid 3176 exit 0
Successful on 4 nodes: ["unmeshed-havoc.delivery.puppetlabs.net, win-2012r2-x86_64", "thick-micelle.delivery.puppetlabs.net, win-2016-core-x86_64", "salty-toolmaker.delivery.puppetlabs.net, win-2019-core-x86_64", "gold-liter.delivery.puppetlabs.net, win-2008r2-x86_64"]
➜  puppetlabs-scheduled_task git:(pdksync_releaseprep0184)`
`Successful on 24 nodes: ["richest-break.delivery.puppetlabs.net, centos-6-x86_64", "sinewy-alfresco.delivery.puppetlabs.net, redhat-6-x86_64", "vulgar-orbit.delivery.puppetlabs.net, scientific-6-x86_64", "loud-malignancy.delivery.puppetlabs.net, oracle-6-x86_64", "insolent-riddle.delivery.puppetlabs.net, sles-12-x86_64", "real-prefecture.delivery.puppetlabs.net, ubuntu-1404-x86_64", "nicer-chastity.delivery.puppetlabs.net, centos-8-x86_64", "reddish-gunfire.delivery.puppetlabs.net, redhat-8-x86_64", "total-reprisal.delivery.puppetlabs.net, oracle-7-x86_64", "olive-aborigine.delivery.puppetlabs.net, debian-8-x86_64", "unpunished-lit.delivery.puppetlabs.net, centos-7-x86_64", "forlorn-orgone.delivery.puppetlabs.net, scientific-7-x86_64", "axial-gnome.delivery.puppetlabs.net, ubuntu-1804-x86_64", "iliac-landscape.delivery.puppetlabs.net, ubuntu-1604-x86_64", "menial-analyst.delivery.puppetlabs.net, debian-9-x86_64", "chromic-shopper.delivery.puppetlabs.net, redhat-7-x86_64", "murky-gabardine.delivery.puppetlabs.net, sles-15-x86_64", "vocalic-axiom.delivery.puppetlabs.net, win-2016-x86_64", "soignee-tire.delivery.puppetlabs.net, centos-5-x86_64", "nubile-manure.delivery.puppetlabs.net, redhat-5-x86_64", "indigent-offer.delivery.puppetlabs.net, oracle-5-x86_64", "lamechian-stamp.delivery.puppetlabs.net, win-2019-x86_64", "steep-coalition.delivery.puppetlabs.net, win-10-pro-x86_64", "low-healer.delivery.puppetlabs.net, win-2012r2-x86_64"]
➜  puppetlabs-package git:(pdksync_releaseprep0184)`
