### PR TITLE
Add optional ignore_dependencies parameter to install_module function

### DIFF
--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -269,8 +269,9 @@ module PuppetLitmus::RakeHelper
   # @param target_node_name [String] the name of the target where the module should be installed
   # @param module_tar [String] the filename of the module tarball to upload
   # @param module_repository [String] the URL for the forge to use for downloading modules. Defaults to the public Forge API.
+  # @param ignore_dependencies [Boolean] flag used to ignore module dependencies defaults to false.
   # @return a bolt result
-  def install_module(inventory_hash, target_node_name, module_tar, module_repository = nil)
+  def install_module(inventory_hash, target_node_name, module_tar, module_repository = nil, ignore_dependencies = false)
     Honeycomb.start_span(name: 'install_module') do |span|
       ENV['HTTP_X_HONEYCOMB_TRACE'] = span.to_trace_header
       span.add_field('litmus.target_node_name', target_node_name)
@@ -290,6 +291,7 @@ module PuppetLitmus::RakeHelper
 
       module_repository_opts = "--module_repository '#{module_repository}'" unless module_repository.nil?
       install_module_command = "puppet module install #{module_repository_opts} #{File.basename(module_tar)}"
+      install_module_command += ' --ignore-dependencies --force' if ignore_dependencies.to_s.downcase == "true" 
       span.add_field('litmus.install_module_command', install_module_command)
 
       bolt_result = run_command(install_module_command, target_nodes, config: nil, inventory: inventory_hash.clone)

--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -291,7 +291,7 @@ module PuppetLitmus::RakeHelper
 
       module_repository_opts = "--module_repository '#{module_repository}'" unless module_repository.nil?
       install_module_command = "puppet module install #{module_repository_opts} #{File.basename(module_tar)}"
-      install_module_command += ' --ignore-dependencies --force' if ignore_dependencies.to_s.downcase == "true" 
+      install_module_command += ' --ignore-dependencies --force' if ignore_dependencies.to_s.downcase == 'true'
       span.add_field('litmus.install_module_command', install_module_command)
 
       bolt_result = run_command(install_module_command, target_nodes, config: nil, inventory: inventory_hash.clone)

--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -195,8 +195,8 @@ namespace :litmus do
   # @param :source [String] source directory to look in (ignores symlinks) defaults do './spec/fixtures/modules'.
   # @param :target_node_name [Array] nodes on which to install a puppet module for testing.
   desc 'build and install all modules from a directory'
-  task :install_modules_from_directory, [:source, :target_node_name, :module_repository] do |_task, args|
-    args.with_defaults(source: nil, target_node_name: nil, module_repository: nil)
+  task :install_modules_from_directory, [:source, :target_node_name, :module_repository, :ignore_dependencies] do |_task, args|
+    args.with_defaults(source: nil, target_node_name: nil, module_repository: nil, ignore_dependencies: false)
     inventory_hash = inventory_hash_from_inventory_file
     target_nodes = find_targets(inventory_hash, args[:target_node_name])
     if target_nodes.empty?
@@ -217,7 +217,7 @@ namespace :litmus do
     module_tars.each do |module_tar|
       puts "Installing '#{module_tar}'"
       target_nodes.each do |target_node_name|
-        install_module(inventory_hash, target_node_name, module_tar, args[:module_repository])
+        install_module(inventory_hash, target_node_name, module_tar, args[:module_repository], args[:ignore_dependencies])
         puts "Installed '#{module_tar}' on #{target_node_name}"
       end
     end


### PR DESCRIPTION
Puppet Litmus is being used on servers that do not external access to the internet, we get errors when trying to run the Puppet Litmus Task **_install_module_**.  This ultimately executes _**puppet module install**_ to install the module which then looks to install module dependencies from Puppet Forge which fails.  To get around this we have tried using the Rake Task **_install_modules_from_directory_**, which also fails as this calls the module_install helper function as above, recusviely for all modules in the specified directory giving the same error.

I have added the optional parameter ignore_dependencies to the install_module function and the rake tasks that call it.  If the ignore_dependencies parameter is set to true then the switches --ignore-dependencies --force are added to the puppet module install command executed