### PR TITLE
Calculate github actions job matrix from metadata.json; fix frozen-string modification in puppet_output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,13 @@ jobs:
       set -x
       git clone --depth 1 https://github.com/puppetlabs/puppetlabs-motd puppetlabs-motd
       cd puppetlabs-motd
+      sed -i -e "s/gem .puppet_litmus./# &/" Gemfile
       echo "gem 'puppet_litmus', require: false, git: 'https://github.com/${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}', branch: '${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}'" >> Gemfile
+
+      echo travis_fold:start:motd-gemfile
+      cat Gemfile
+      echo travis_fold:end:motd-gemfile
+
       # override travis' defaults
       unset BUNDLE_GEMFILE
       bundle config gemfile ./Gemfile

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,12 @@ for:
         }
         Write-Host $URL
         Write-Host $Branch
+
+        (Get-Content Gemfile).Replace('gem "puppet_litmus"', '# gem "puppet_litmus"') | Set-Content Gemfile
+
         "gem 'puppet_litmus', require: false, git: $URL, branch: $Branch" >> Gemfile
+
+        type Gemfile
 
         bundle config gemfile ./Gemfile
         if(-not $?) { Write-Error -Message "failed to set gemfile" }

--- a/exe/matrix_from_metadata
+++ b/exe/matrix_from_metadata
@@ -1,0 +1,62 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# this script creates a build matrix for github actions from the claimed supported platforms in metadata.json
+
+require 'json'
+
+IMAGE_TABLE = {
+  'RedHat-6' => 'rhel-6-v20200618',
+  'RedHat-7' => 'rhel-7-v20200618',
+  'RedHat-8' => 'rhel-8-v20200811',
+  'SLES-12' => 'sles-12-sp5-v20200610',
+  'SLES-15' => 'sles-15-sp1-v20200610',
+  'Windows-2012 R2' => 'windows-server-2012-r2-dc-core-v20200609',
+  'Windows-2016' => 'windows-server-2016-dc-core-v20200609',
+  'Windows-2019' => 'windows-server-2019-dc-core-v20200609',
+}.freeze
+
+DOCKER_PLATFORMS = [
+  'CentOS-6',
+  'CentOS-7',
+  'CentOS-8',
+  'Debian-10',
+  'Debian-8',
+  'Debian-9',
+  'OracleLinux-6',
+  'OracleLinux-7',
+  'Scientific-6',
+  'Scientific-7',
+  'Ubuntu-14.04',
+  'Ubuntu-16.04',
+  'Ubuntu-18.04',
+  'Ubuntu-20.04',
+].freeze
+
+matrix = {
+  platform: [],
+  collection: %w[
+    puppet5
+    puppet6
+    puppet7-nightly
+  ],
+}
+
+metadata = JSON.parse(File.read('metadata.json'))
+metadata['operatingsystem_support'].sort_by { |a| a['operatingsystem'] }.each do |sup|
+  os = sup['operatingsystem']
+  sup['operatingsystemrelease'].sort_by { |a| a.to_i }.each do |ver|
+    image_key = "#{os}-#{ver}"
+    if IMAGE_TABLE.key? image_key
+      matrix[:platform] << IMAGE_TABLE[image_key]
+    elsif DOCKER_PLATFORMS.include? image_key
+      puts "Expecting #{image_key} test using docker on travis"
+    else
+      puts "::warning::Cannot find image for #{image_key}"
+    end
+  end
+end
+
+puts "::set-output name=matrix::#{JSON.generate(matrix)}"
+
+puts "Created matrix with #{matrix[:platform].length * matrix[:collection].length} cells."

--- a/lib/puppet_litmus/puppet_helpers.rb
+++ b/lib/puppet_litmus/puppet_helpers.rb
@@ -418,7 +418,7 @@ module PuppetLitmus::PuppetHelpers
 
   # Return the stdout of the puppet run
   def puppet_output(bolt_result)
-    bolt_result.dig(0, 'value', 'stderr').to_s << \
+    bolt_result.dig(0, 'value', 'stderr').to_s + \
       bolt_result.dig(0, 'value', 'stdout').to_s
   end
 

--- a/puppet_litmus.gemspec
+++ b/puppet_litmus.gemspec
@@ -12,9 +12,12 @@ Gem::Specification.new do |spec|
   spec.files       = Dir[
     'README.md',
     'LICENSE',
+    'exe/**/*',
     'lib/**/*',
     'spec/**/*',
   ]
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.test_files  = Dir['spec/**/*']
   spec.description = <<-EOF
     Providing a simple command line tool for puppet content creators, to enable simple and complex test deployments.


### PR DESCRIPTION
The `matrix_from_metadata` executable supports creating a platform
matrix for the new cloud-ci project based off the `metadata.json`
in the current module.