### PR TITLE
simplify GCP images to use family names

### DIFF
--- a/exe/matrix_from_metadata
+++ b/exe/matrix_from_metadata
@@ -6,14 +6,14 @@
 require 'json'
 
 IMAGE_TABLE = {
-  'RedHat-6' => 'rhel-6-v20200618',
-  'RedHat-7' => 'rhel-7-v20200618',
-  'RedHat-8' => 'rhel-8-v20200811',
-  'SLES-12' => 'sles-12-sp5-v20200610',
-  'SLES-15' => 'sles-15-sp1-v20200610',
-  'Windows-2012 R2' => 'windows-server-2012-r2-dc-core-v20200609',
-  'Windows-2016' => 'windows-server-2016-dc-core-v20200609',
-  'Windows-2019' => 'windows-server-2019-dc-core-v20200609',
+  'RedHat-6' => 'rhel-6',
+  'RedHat-7' => 'rhel-7',
+  'RedHat-8' => 'rhel-8',
+  'SLES-12' => 'sles-12',
+  'SLES-15' => 'sles-15',
+  'Windows-2012 R2' => 'windows-2012-r2-core',
+  'Windows-2016' => 'windows-2016-core',
+  'Windows-2019' => 'windows-2019-core',
 }.freeze
 
 DOCKER_PLATFORMS = [


### PR DESCRIPTION
See https://cloud.google.com/compute/docs/images#image_families and `gcloud compute images list`.