### PR TITLE
Use default windows-2016 server image

### DIFF
--- a/exe/matrix_from_metadata
+++ b/exe/matrix_from_metadata
@@ -12,7 +12,7 @@ IMAGE_TABLE = {
   'SLES-12' => 'sles-12',
   'SLES-15' => 'sles-15',
   'Windows-2012 R2' => 'windows-2012-r2-core',
-  'Windows-2016' => 'windows-2016-core',
+  'Windows-2016' => 'windows-2016',
   'Windows-2019' => 'windows-2019-core',
 }.freeze
 


### PR DESCRIPTION
The windows-2016 core image seems to have a transient failures in setting up the environment after a Puppet Agent 6 install

On boot-up there seems to be a COM+ issue in the EventLog:
![image](https://user-images.githubusercontent.com/6704579/98814935-12a81400-242f-11eb-8d6d-d60d1a7ce5ce.png)
