### PR TITLE
(GH-326) - Return node name when testing is complete

### DIFF
--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -389,9 +389,9 @@ namespace :litmus do
           # because we cannot modify variables inside of Parallel
           results.each do |result|
             if result.last.to_i.zero?
-              success_list.push(result.first.scan(%r{.*})[2])
+              success_list.push(result.first.scan(%r{.*})[3])
             else
-              failure_list.push(result.first.scan(%r{.*})[2])
+              failure_list.push(result.first.scan(%r{.*})[3])
             end
           end
           Thread.kill(progress)


### PR DESCRIPTION
Currently when `CI=true bundle exec rake 'litmus:acceptance:parallel'` is ran it returns `" "`. 

This change means it now returns the node name and OS information. 

Example: 
`CI=true bundle exec rake 'litmus:acceptance:parallel'`
`Successful on 1 nodes: ["localhost:2227, litmusimage/oraclelinux:6"]`
`bundle exec rake 'litmus:acceptance:parallel'`
`Successful on 1 nodes: ["machine_name.puppet, centos-7-x86_64"]`

`CI=true bundle exec rake 'litmus:acceptance:parallel'`
`Failed on 1 nodes: ["localhost:2227, litmusimage/oraclelinux:6"]`
`bundle exec rake 'litmus:acceptance:parallel'`
`Failed on 1 nodes: ["machine_name.puppet, centos-7-x86_64"]`

Fixes #326 