### PR TITLE
(maint) fix install_agent error

### DIFF
--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -208,11 +208,11 @@ module PuppetLitmus::RakeHelper
   def configure_path(inventory_hash)
     results = []
     # fix the path on ssh_nodes
-    unless inventory_hash['groups'].select { |group| group['name'] == 'ssh_nodes' }.size.zero?
+    unless inventory_hash['groups'].select { |group| group['name'] == 'ssh_nodes' && !group['targets'].empty? }.size.zero?
       results << run_command('echo PATH="$PATH:/opt/puppetlabs/puppet/bin" > /etc/environment',
                              'ssh_nodes', config: nil, inventory: inventory_hash)
     end
-    unless inventory_hash['groups'].select { |group| group['name'] == 'winrm_nodes' }.size.zero?
+    unless inventory_hash['groups'].select { |group| group['name'] == 'winrm_nodes' && !group['targets'].empty? }.size.zero?
       results << run_command('[Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\Program Files\Puppet Labs\Puppet\bin;C:\Program Files (x86)\Puppet Labs\Puppet\bin", "Machine")',
                              'winrm_nodes', config: nil, inventory: inventory_hash)
     end

--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -135,9 +135,7 @@ namespace :litmus do
           # fix the path
           path_changes = configure_path(inventory_hash)
           path_changes.each do |change|
-            if change['status'] != 'success'
-              puts "Failed on #{change['target']}\n#{change}"
-            end
+            puts "Configuring puppet path result: #{change.inspect}"
           end
 
           retries += 1


### PR DESCRIPTION
Request for a review.
configure_path function always returns multiple hashes in an array hence it throws the error while accessing change['status'] which doesn't exists
inventory_hash['groups'].select { |group| group['name'] == 'ssh_nodes' }.size.zero? always returns value greater than zero if the targets is empty so adding the following condition to return the group where targets are not empty.

