### PR TITLE
Revert "Use puppet 7 collection in acceptance test matrix"

### DIFF
--- a/exe/matrix_from_metadata
+++ b/exe/matrix_from_metadata
@@ -38,7 +38,7 @@ matrix = {
   collection: %w[
     puppet5
     puppet6
-    puppet7
+    puppet7-nightly
   ],
 }
 


### PR DESCRIPTION
This reverts commit a3075ed858a34742e50e6570bdc536c6e1b5bc42.