### PR TITLE
Convert inventory vars to JSON

### DIFF
--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -134,8 +134,9 @@ module PuppetLitmus::RakeHelper
   end
 
   def provision_list(provision_hash, key)
+    require 'json'
     provisioner = provision_hash[key]['provisioner']
-    inventory_vars = provision_hash[key]['vars']
+    inventory_vars = provision_hash[key]['vars'].to_json unless provision_hash[key]['vars'].nil?
     # Splat the params into environment variables to pass to the provision task but only in this runspace
     provision_hash[key]['params']&.each { |k, value| ENV[k.upcase] = value.to_s }
     results = []

--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -24,13 +24,15 @@ namespace :litmus do
   task :provision_list, [:key] do |_task, args|
     raise 'Cannot find provision.yaml file' unless File.file?('./provision.yaml')
 
+    require 'json'
+
     provision_hash = YAML.load_file('./provision.yaml')
     raise "No key #{args[:key]} in ./provision.yaml, see https://puppetlabs.github.io/litmus/Litmus-core-commands.html#provisioning-via-yaml for examples" if provision_hash[args[:key]].nil?
 
     Rake::Task['spec_prep'].invoke
 
     provisioner = provision_hash[args[:key]]['provisioner']
-    inventory_vars = provision_hash[args[:key]]['vars']
+    inventory_vars = provision_hash[args[:key]]['vars'].to_json unless provision_hash[args[:key]]['vars'].nil?
     # Splat the params into environment variables to pass to the provision task but only in this runspace
     provision_hash[args[:key]]['params']&.each { |k, value| ENV[k.upcase] = value.to_s }
     results = []

--- a/spec/lib/puppet_litmus/rake_helper_spec.rb
+++ b/spec/lib/puppet_litmus/rake_helper_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe PuppetLitmus::RakeHelper do
     end
   end
 
+  context 'with provision_list and vars' do
+    let(:provision_hash) { { 'default' => { 'provisioner' => 'docker', 'images' => ['waffleimage/centos7'], 'vars' => { 'foo' => 'bar' } } } }
+    let(:results) { [] }
+
+    it 'calls function' do
+      expect(self).to receive(:provision).with('docker', 'waffleimage/centos7', '{"foo":"bar"}').and_return(results)
+      provision_list(provision_hash, 'default')
+    end
+  end
+
   context 'with provision' do
     examples = [
       {


### PR DESCRIPTION
Prior to this commit, the inventory_vars were passed to the provisioners
as a struct. The provisioners expect `vars` as a JSON formatted string,
which would cause failures in provisioning when `vars` was populated.
This commit changes the format of vars to be a string before it is
passed into `provision`.