### PR TITLE
Remove rhel6 from all tests

### DIFF
--- a/exe/matrix_from_metadata
+++ b/exe/matrix_from_metadata
@@ -6,7 +6,6 @@
 require 'json'
 
 IMAGE_TABLE = {
-  'RedHat-6' => 'rhel-6',
   'RedHat-7' => 'rhel-7',
   'RedHat-8' => 'rhel-8',
   'SLES-12' => 'sles-12',


### PR DESCRIPTION
RHEL6 is out of public support and we want to stop testing against it.