### PR TITLE
Remove optional parameter append_cli from provision api

### DIFF
--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -116,13 +116,12 @@ module PuppetLitmus::RakeHelper
     end
   end
 
-  def provision(provisioner, platform, inventory_vars, append_cli = nil)
+  def provision(provisioner, platform, inventory_vars)
     include ::BoltSpec::Run
     raise "the provision module was not found in #{DEFAULT_CONFIG_DATA['modulepath']}, please amend the .fixtures.yml file" unless
       File.directory?(File.join(DEFAULT_CONFIG_DATA['modulepath'], 'provision'))
 
     params = { 'action' => 'provision', 'platform' => platform, 'inventory' => Dir.pwd }
-    params['append_cli'] = append_cli unless append_cli.nil?
     params['vars'] = inventory_vars unless inventory_vars.nil?
 
     Honeycomb.add_field_to_trace('litmus.provisioner', provisioner)


### PR DESCRIPTION
The `append_cli` option was only used by the `docker_exp` provisioner. The `docker` provisioner used `docker_run_opts` in the vars. PR https://github.com/puppetlabs/provision/pull/151 adds the changes so the `docker` and `docker_exp` both use `docker_run_opts` for passing options to the docker command.