### PR TITLE
(IAC-1287) Only log transient provisioning errors in debug mode

### DIFF
--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -138,10 +138,10 @@ namespace :litmus do
             raise "Error checking puppet version on #{response.to_json}" if response['status'] != 'success'
           end
         rescue StandardError => e
-          puts "ERROR:#{e}"
+          puts "ERROR:#{e}" if ENV['DEBUG'] == 'true'
           # fix the path
           path_changes = configure_path(inventory_hash)
-          if ENV['DEBUG'] == true
+          if ENV['DEBUG'] == 'true'
             path_changes.each do |change|
               puts "Configuring puppet path result: #{change.inspect}"
             end


### PR DESCRIPTION
End users are only used to seeing output when using litmus if something
goes wrong. Setting so that the additional information can only be seen
when DEBUG=true is set.

This is #366 rebased and fix'er'upped.