### PR TITLE
(IAC-1365) - Workaround bolt/windows/exitcode bug

### DIFF
--- a/lib/puppet_litmus/puppet_helpers.rb
+++ b/lib/puppet_litmus/puppet_helpers.rb
@@ -83,22 +83,19 @@ module PuppetLitmus::PuppetHelpers
       command_to_run += ' --noop' if !opts[:noop].nil? && (opts[:noop] == true)
       command_to_run += ' --detailed-exitcodes' if use_detailed_exit_codes == true
 
+      command_to_run = "try { #{command_to_run}; exit $LASTEXITCODE } catch { write-error $_ ; exit 1 }" if os[:family] == 'windows'
+
       span.add_field('litmus.command_to_run', command_to_run)
       span.add_field('litmus.target_node_name', target_node_name)
       # IAC-1365 - Workaround for BOLT-1535 and bolt issue #1650
       # bolt_result = run_command(command_to_run, target_node_name, config: nil, inventory: inventory_hash)
-      script = Tempfile.open(['temp', '.ps1'])
-      if os[:family] == 'windows'
-        script.write("try { #{command_to_run}; exit $LASTEXITCODE } catch { write-error $_ ; exit 1 }")
-      else
-        script.write(command_to_run.to_s)
+      bolt_result = Tempfile.open(['temp', '.ps1']) do |script|
+        script.write(command_to_run)
+        script.close
+        run_script(script.path, target_node_name, [], options: {}, config: nil, inventory: inventory_hash)
       end
-      script.rewind
-      bolt_result = run_script(script.path, target_node_name, [], options: {}, config: nil, inventory: inventory_hash)
-      script.close
-      script.unlink
-      span.add_field('litmus.bolt_result', bolt_result)
 
+      span.add_field('litmus.bolt_result', bolt_result)
       result = OpenStruct.new(exit_code: bolt_result.first['value']['exit_code'],
                               stdout: bolt_result.first['value']['stdout'],
                               stderr: bolt_result.first['value']['stderr'])


### PR DESCRIPTION
Alter the `apply_manifest` helper method to utilize the litmus `run_script` command, via the existing `bolt_run_script` helper method, instead of the original litmus `run_command` in order to sidestep a bug surrounding the retrieval of exit codes.
Windows requires some special code in order to properly retrieve the exit codes from within powershell scripts.