### PR TITLE
(GH-380) Moving inventory.yaml to /spec/fixtures/litmus_inventory.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Litmus also facilitates parallel test runs and running tests in isolation. Each 
 
 Install Litmus as a gem by running ```gem install puppet_litmus```.
 
+* Note if you choose to override the `litmus_inventory.yaml` location, please ensure that the directory strutcture you define exists.
+
 ## Documentation
 
 For documentation, see our [Litmus Docs Site](https://puppetlabs.github.io/litmus/).

--- a/lib/puppet_litmus/inventory_manipulation.rb
+++ b/lib/puppet_litmus/inventory_manipulation.rb
@@ -11,7 +11,7 @@ module PuppetLitmus::InventoryManipulation
   def inventory_hash_from_inventory_file(inventory_full_path = nil)
     require 'yaml'
     inventory_full_path = if inventory_full_path.nil?
-                            'inventory.yaml'
+                            "#{Dir.pwd}/spec/fixtures/litmus_inventory.yaml"
                           else
                             inventory_full_path
                           end


### PR DESCRIPTION
- Renaming the inventory.yaml file to litmus_inventory.yaml
- Relocating file from the module root directory to /spec/fixtures/
- Removal of vmpooler as it is deprecated

The point in this change is to avoid running tests on a live production system by accident.

This piece of work includes changes in multiple places. 

1. pdk-templates: https://github.com/puppetlabs/pdk-templates/pull/414
2. puppet_litmus: https://github.com/puppetlabs/puppet_litmus/pull/396
3. provision module: https://github.com/puppetlabs/provision/pull/161

The follow PR is testing out my changes: https://github.com/puppetlabs/puppetlabs-testing/pull/353
