### PR TITLE
(maint) Release prep v0.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v0.26.2](https://github.com/puppetlabs/puppet_litmus/tree/v0.26.2) (2021-04-12)
+
+[Full Changelog](https://github.com/puppetlabs/puppet_litmus/compare/v0.26.1...v0.26.2)
+
+### Fixed
+
+- \(bugfix\) Update inventory path [\#403](https://github.com/puppetlabs/puppet_litmus/pull/403) ([pmcmaw](https://github.com/pmcmaw))
+
 ## [v0.26.1](https://github.com/puppetlabs/puppet_litmus/tree/v0.26.1) (2021-04-12)
 
 [Full Changelog](https://github.com/puppetlabs/puppet_litmus/compare/v0.26.0...v0.26.1)

--- a/lib/puppet_litmus/version.rb
+++ b/lib/puppet_litmus/version.rb
@@ -2,5 +2,5 @@
 
 # version of this gem
 module PuppetLitmus
-  VERSION ||= '0.26.1'
+  VERSION ||= '0.26.2'
 end


### PR DESCRIPTION
inventory path was missed in the helper functions. 