### PR TITLE
(maint) Update bolt requirement to include 3.x

### DIFF
--- a/puppet_litmus.gemspec
+++ b/puppet_litmus.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   EOF
   spec.summary = 'Providing a simple command line tool for puppet content creators, to enable simple and complex test deployments.'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
-  spec.add_runtime_dependency 'bolt',        ['>= 2.0.1', '< 3.0.0']
+  spec.add_runtime_dependency 'bolt',        ['>= 2.0.1', '< 4.0.0']
   spec.add_runtime_dependency 'puppet-modulebuilder', ['>= 0.2.1', '< 1.0.0']
   spec.add_runtime_dependency 'tty-spinner', ['>= 0.5.0', '< 1.0.0']
   spec.add_runtime_dependency 'docker-api',  '>= 1.34', '< 3.0.0'


### PR DESCRIPTION
This updates the requirement for the `bolt` gem so the 3.x series can be
used.