### PR TITLE
(maint) - Increase the connection timeout limit

### DIFF
--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -464,7 +464,7 @@ module PuppetLitmus::RakeHelper
 
   class LitmusTimeoutError < StandardError; end
 
-  def with_retries(options: { tries: Float::INFINITY }, max_wait_minutes: 8)
+  def with_retries(options: { tries: Float::INFINITY }, max_wait_minutes: 15)
     stop = Time.now + (max_wait_minutes * 60)
     Retryable.retryable(options.merge(not: [LitmusTimeoutError])) do
       raise LitmusTimeoutError if Time.now > stop


### PR DESCRIPTION
Due to recent changes the setup time for windows machines on GCP has increased and so the timeout limit needs to be raised accordingly.