### PR TITLE
Allow Litmus Functions to accept a target

### DIFF
--- a/requirements.md
+++ b/requirements.md
@@ -1,0 +1,12 @@
+1. attach to a parameter call target:
+2. Target should accept strings that are defined as
+  a. Specific Target URIs
+  b. An inventory group name
+  c. The name of a role
+3. The parameter should accept either or both of string or symbol
+4. The parameter should accept a single value or an array
+5. The search for a target name should
+  a. Should be tolerant to role values that are either a single value or an array of roles
+  b. Should be tolerant to the role variable being called either `role` or `roles`
+
+There is a possibility that if multiple single targets are returned, the format of the value given to the BoltSpec function will have to be changed or constructed in a specific way.

--- a/spec/support/inventory.rb
+++ b/spec/support/inventory.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+def no_config_hash
+  { 'groups' =>
+    [
+      { 'name' => 'ssh_nodes',
+        'targets' =>
+      [{ 'uri' => 'test.delivery.puppetlabs.net',
+         'facts' => { 'provisioner' => 'vmpooler', 'platform' => 'centos-5-x86_64' } }] },
+      { 'name' => 'winrm_nodes', 'targets' => [] },
+    ] }
+end
+
+def no_docker_hash
+  { 'groups' =>
+    [{ 'name' => 'ssh_nodes', 'targets' => [] },
+     { 'name' => 'winrm_nodes', 'targets' => [] }] }
+end
+
+def config_hash
+  { 'groups' =>
+[{ 'name' => 'ssh_nodes',
+   'targets' =>
+ [{ 'uri' => 'test.delivery.puppetlabs.net',
+    'config' => { 'transport' => 'ssh', 'ssh' => { 'user' => 'root', 'password' => 'Qu@lity!', 'host-key-check' => false } },
+    'facts' => { 'provisioner' => 'vmpooler', 'platform' => 'centos-5-x86_64' },
+    'vars' => { 'role' => 'agent' } }] },
+ { 'name' => 'winrm_nodes', 'targets' => [] }] }
+end
+
+def no_feature_hash
+  { 'groups' =>
+[{ 'name' => 'ssh_nodes',
+   'targets' =>
+ [{ 'uri' => 'test.delivery.puppetlabs.net',
+    'config' => { 'transport' => 'ssh', 'ssh' => { 'user' => 'root', 'password' => 'Qu@lity!', 'host-key-check' => false } },
+    'facts' => { 'provisioner' => 'vmpooler', 'platform' => 'centos-5-x86_64' } }] },
+ { 'name' => 'winrm_nodes', 'targets' => [] }] }
+end
+
+def feature_hash_group
+  { 'groups' =>
+[{ 'name' => 'ssh_nodes',
+   'targets' =>
+ [{ 'uri' => 'test.delivery.puppetlabs.net',
+    'config' => { 'transport' => 'ssh', 'ssh' => { 'user' => 'root', 'password' => 'Qu@lity!', 'host-key-check' => false } },
+    'facts' => { 'provisioner' => 'vmpooler', 'platform' => 'centos-5-x86_64' } }],
+   'features' => ['puppet-agent'] },
+ { 'name' => 'winrm_nodes', 'targets' => [] }] }
+end
+
+def empty_feature_hash_group
+  { 'groups' =>
+[{ 'name' => 'ssh_nodes',
+   'targets' =>
+ [{ 'uri' => 'test.delivery.puppetlabs.net',
+    'config' => { 'transport' => 'ssh', 'ssh' => { 'user' => 'root', 'password' => 'Qu@lity!', 'host-key-check' => false } },
+    'facts' => { 'provisioner' => 'vmpooler', 'platform' => 'centos-5-x86_64' } }],
+   'features' => [] },
+ { 'name' => 'winrm_nodes', 'targets' => [] }] }
+end
+
+def feature_hash_node
+  { 'groups' =>
+[{ 'name' => 'ssh_nodes',
+   'targets' =>
+ [{ 'uri' => 'test.delivery.puppetlabs.net',
+    'config' => { 'transport' => 'ssh', 'ssh' => { 'user' => 'root', 'password' => 'Qu@lity!', 'host-key-check' => false } },
+    'facts' => { 'provisioner' => 'vmpooler', 'platform' => 'centos-5-x86_64' },
+    'features' => ['puppet-agent'] }] },
+ { 'name' => 'winrm_nodes', 'targets' => [] }] }
+end
+
+def empty_feature_hash_node
+  { 'groups' =>
+[{ 'name' => 'ssh_nodes',
+   'targets' =>
+ [{ 'uri' => 'test.delivery.puppetlabs.net',
+    'config' => { 'transport' => 'ssh', 'ssh' => { 'user' => 'root', 'password' => 'Qu@lity!', 'host-key-check' => false } },
+    'facts' => { 'provisioner' => 'vmpooler', 'platform' => 'centos-5-x86_64' },
+    'features' => [] }] },
+ { 'name' => 'winrm_nodes', 'targets' => [] }] }
+end
+
+def foo_node
+  { 'uri' => 'foo',
+    'facts' => { 'provisioner' => 'bar', 'platform' => 'ubuntu' } }
+end
+
+def complex_inventory
+  { 'groups' =>
+    [
+      {
+        'name' => 'ssh_nodes',
+        'groups' => [
+          { 'name' => 'frontend',
+            'targets' => [
+              {
+                'uri' => 'test.delivery.puppetlabs.net',
+                'config' => { 'transport' => 'ssh', 'ssh' => { 'user' => 'root', 'password' => 'Qu@lity!', 'host-key-check' => false } },
+                'facts' => { 'provisioner' => 'vmpooler', 'platform' => 'centos-5-x86_64' },
+                'vars' => { 'role' => 'agent' },
+              },
+              {
+                'uri' => 'test2.delivery.puppetlabs.net',
+                'config' => { 'transport' => 'ssh', 'ssh' => { 'user' => 'root', 'password' => 'Qu@lity!', 'host-key-check' => false } },
+                'facts' => { 'provisioner' => 'vmpooler', 'platform' => 'centos-5-x86_64' },
+                'vars' => { 'role' => 'server' },
+              },
+              {
+                'uri' => 'test3.delivery.puppetlabs.net',
+                'config' => { 'transport' => 'ssh', 'ssh' => { 'user' => 'root', 'password' => 'Qu@lity!', 'host-key-check' => false } },
+                'vars' => { 'roles' => %w[agent nginx webserver] },
+              },
+            ] },
+        ],
+      },
+      {
+        'name' => 'winrm_nodes',
+        'targets' => [
+          {
+            'uri' => 'test4.delivery.puppetlabs.net',
+            'config' => { 'transport' => 'winrm', 'winrm' => { 'user' => 'admin', 'password' => 'Qu@lity!' } },
+            'facts' => { 'provisioner' => 'vmpooler', 'platform' => 'centos-5-x86_64' },
+            'vars' => { 'roles' => %w[agent iis webserver] },
+          },
+        ],
+      },
+    ] }
+end

--- a/spec/support/inventorytesting.yaml
+++ b/spec/support/inventorytesting.yaml
@@ -1,0 +1,41 @@
+groups:
+  - name: ssh_nodes
+    groups:
+      - name: webservers
+        targets:
+          - 192.168.100.179
+          - 192.168.100.180
+          - 192.168.100.181
+      - name: memcached
+        targets:
+          - 192.168.101.50
+          - 192.168.101.60
+        config:
+          ssh:
+            user: root
+    config:
+      transport: ssh
+      ssh:
+        user: centos
+        private-key: ~/.ssh/id_rsa
+        host-key-check: false
+  - name: win_nodes
+    groups:
+      - name: domaincontrollers
+        targets:
+          - 192.168.110.10
+          - 192.168.110.20
+      - name: testservers
+        targets:
+          - 172.16.219.20
+          - 172.16.219.30
+        config:
+          winrm:
+            realm: MYDOMAIN
+            ssl: false
+    config:
+      transport: winrm
+      winrm:
+        user: DOMAIN\opsaccount
+        password: S3cretP@ssword
+        ssl: true


### PR DESCRIPTION
(ISSUE 418) Accept a Target in Litmus Functions

This change will allow users to specify a target for each invocation of
a Litmus Puppet Helper. Specifying a target will not affect the current
value of the `ENV['TARGET_HOST']` variable.

Targets can be specified by using strings or symbols. Targets can be:
1. The name of a role assigned to a target via the `vars => roles` hash
of the target.
2. The name of a group in the inventory
3. The name of a specific target URI

The roles key in the inventory can be
1. Called either `Role` or `Roles`
2. Can have a single role `role: webserver` or an array:
  ```
  roles:
    - IIS
    - Webserver
    - Frontend
  ```
3. Values are searched in a case insensitive manner such that
  `'webserver' == 'Webserver'`

Closes #418

Co-authored-by: Daniel Carabas <daniel.carabas@puppet.com>