### PR TITLE
Remove support for rhel docker images that no longer exist

### DIFF
--- a/exe/matrix_from_metadata
+++ b/exe/matrix_from_metadata
@@ -6,8 +6,6 @@
 require 'json'
 
 IMAGE_TABLE = {
-  'RedHat-7' => 'rhel-7',
-  'RedHat-8' => 'rhel-8',
   'SLES-12' => 'sles-12',
   'SLES-15' => 'sles-15',
   'Windows-2012 R2' => 'windows-2012-r2-core',

--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -6,8 +6,6 @@
 require 'json'
 
 IMAGE_TABLE = {
-  'RedHat-7' => 'rhel-7',
-  'RedHat-8' => 'rhel-8',
   'SLES-12' => 'sles-12',
   'SLES-15' => 'sles-15',
   'Windows-2012 R2' => 'windows-2012-r2-core',

--- a/spec/exe/matrix_from_metadata_v2_spec.rb
+++ b/spec/exe/matrix_from_metadata_v2_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe 'matrix_from_metadata_v2' do
     end
 
     it 'generates the matrix' do
+      expect(result.stdout).to include('::warning::Cannot find image for RedHat-8')
       expect(result.stdout).to include('::warning::Cannot find image for Ubuntu-14.04')
       expect(result.stdout).to include(
         [
           '::set-output name=matrix::{',
           '"platforms":[',
           '{"label":"CentOS-6","provider":"provision::docker","image":"litmusimage/centos:6"},',
-          '{"label":"RedHat-8","provider":"provision::provision_service","image":"rhel-8"},',
           '{"label":"Ubuntu-18.04","provider":"provision::docker","image":"litmusimage/ubuntu:18.04"}',
           '],',
           '"collection":[',
@@ -29,7 +29,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
       expect(result.stdout).to include(
         '::set-output name=spec_matrix::{"include":[{"puppet_version":"~> 6.0","ruby_version":2.5},{"puppet_version":"~> 7.0","ruby_version":2.7}]}',
       )
-      expect(result.stdout).to include("Created matrix with 8 cells:\n  - Acceptance Test Cells: 6\n  - Spec Test Cells: 2")
+      expect(result.stdout).to include("Created matrix with 6 cells:\n  - Acceptance Test Cells: 4\n  - Spec Test Cells: 2")
     end
   end
 
@@ -41,14 +41,14 @@ RSpec.describe 'matrix_from_metadata_v2' do
     end
 
     it 'generates the matrix without excluded platforms' do
+      expect(result.stdout).to include('::warning::Cannot find image for RedHat-8')
       expect(result.stdout).to include('::warning::Cannot find image for Ubuntu-14.04')
       expect(result.stdout).to include('::warning::Ubuntu-18.04 was excluded from testing')
       expect(result.stdout).to include(
         [
           '::set-output name=matrix::{',
           '"platforms":[',
-          '{"label":"CentOS-6","provider":"provision::docker","image":"litmusimage/centos:6"},',
-          '{"label":"RedHat-8","provider":"provision::provision_service","image":"rhel-8"}',
+          '{"label":"CentOS-6","provider":"provision::docker","image":"litmusimage/centos:6"}',
           '],',
           '"collection":[',
           '"puppet6-nightly","puppet7-nightly"',
@@ -59,7 +59,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
       expect(result.stdout).to include(
         '::set-output name=spec_matrix::{"include":[{"puppet_version":"~> 6.0","ruby_version":2.5},{"puppet_version":"~> 7.0","ruby_version":2.7}]}',
       )
-      expect(result.stdout).to include("Created matrix with 6 cells:\n  - Acceptance Test Cells: 4\n  - Spec Test Cells: 2")
+      expect(result.stdout).to include("Created matrix with 4 cells:\n  - Acceptance Test Cells: 2\n  - Spec Test Cells: 2")
     end
   end
 


### PR DESCRIPTION
I've removed the RedHat-7/8 support from the code as the non-namespaced `rhel-7` and `rhel-8` images are no longer available on the docker hub and I wasn't able to find any functioning alternatives to replace them.

I've tried the [official UBI images](https://hub.docker.com/u/redhat), but currently `puppetlabs/provision` [does not have support](https://github.com/puppetlabs/provision/blob/main/tasks/docker.rb#L20) for `rhel` distro that UBI reports. And even if I fork it and add it, RedHat [objects adding OpenSSH server to their repos](https://bugzilla.redhat.com/show_bug.cgi?id=1750907) for UBI, so litmus won't be able to connect there. As for the non-UBI images, I didn't find one that is both maintained and has systemd set up properly so that they could run services.

Without this change, litmus fails with something like

```
localhost: {"_error"=>{"kind"=>"provision/docker_failure", "msg"=>"Attempted to run\ncommand:'docker run -d -it --privileged  --tmpfs /tmp:exec -p 2222:22 --name rhel-7-2222 rhel-7'\nstdout:\nstderr:Unable to find image 'rhel-7:latest' locally\ndocker: Error response from daemon: pull access denied for rhel-7, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.\nSee 'docker run --help'.\n", "backtrace"=>["/tmp/4d3453a8-0565-43e7-80a1-c9923604b48d/provision/lib/task_helper.rb:21:in `run_local_command'", "/tmp/4d3453a8-0565-43e7-80a1-c9923604b48d/provision/tasks/docker.rb:156:in `provision'", "/tmp/4d3453a8-0565-43e7-80a1-c9923604b48d/provision/tasks/docker.rb:198:in `<main>'"], "details"=>{}}}}
```

I would gladly update this PR if someone points me at images that I can use instead.