### PR TITLE
(FM-8922) Re-enable support for Windows 2022

### DIFF
--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -13,7 +13,7 @@ IMAGE_TABLE = {
   'Windows-2012 R2' => 'windows-2012-r2-core',
   'Windows-2016' => 'windows-2016',
   'Windows-2019' => 'windows-2019-core',
-  # 'Windows-2022' => 'windows-2022', Image not yet available in GCP/Cloud-CI; no date on availability, but this can be uncommented then
+  'Windows-2022' => 'windows-2022',
 }.freeze
 
 DOCKER_PLATFORMS = {


### PR DESCRIPTION
OS is now support on the GCP so can be re-enabled