### PR TITLE
(CONT-177) - Restructuring of Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In order to use this new functionality just simply run:
 
 ## Documentation
 
-For documentation, see our [Litmus Docs Site](https://puppetlabs.github.io/litmus/).
+For documentation, see our [Litmus Docs Site](https://puppetlabs.github.io/content-and-tooling-team/docs/litmus/).
 
 ## Other Resources
 

--- a/docs/md/content/about.md
+++ b/docs/md/content/about.md
@@ -1,0 +1,22 @@
+---
+title: About Litmus
+layout: page
+description: An overview of Litmus.
+weight: 1
+---
+
+Litmus is a command line tool that allows you to run acceptance tests against Puppet modules for a variety of OSes and deployment scenarios.
+
+Litmus is installed as (experimental) part of the [Puppet Development Kit](https://puppet.com/try-puppet/puppet-development-kit/).
+
+* Start with [running acceptance tests with Litmus](/content-and-tooling-team/docs/litmus/usage/testing/running-acceptance-tests/). This example that walks you through running an acceptance test on a module that already has Litmus tests.
+* Follow the [Converting modules to use Litmus](/content-and-tooling-team/docs/litmus/usage/converting-modules-to-use-litmus/) to enable Litmus on your module.
+* [Litmus core commands](/content-and-tooling-team/docs/litmus/usage/commands/litmus-core-commands/) has a list of what else you can do with it.
+* [Litmus Concepts](/content-and-tooling-team/docs/litmus/litmus-concepts/) explains the concepts, parts and their connection inside litmus.
+
+Other pages on this site:
+
+* [Tools included in Litmus](/content-and-tooling-team/docs/litmus/usage/tools-included-in-litmus/). An overview of the tools Litmus uses.
+* [Test examples](/content-and-tooling-team/docs/litmus/usage/testing/litmus-test-examples/). Common examples you can use in your tests.
+* [Helper functions](/content-and-tooling-team/docs/litmus/usage/litmus-helper-functions/). A list of the helper functions that you can use in your tests.
+* [Command reference](/content-and-tooling-team/docs/litmus/usage/commands/command-reference/). Including useful Docker commands.

--- a/docs/md/content/litmus-concepts.md
+++ b/docs/md/content/litmus-concepts.md
@@ -1,0 +1,313 @@
+---
+layout: page
+title: Concepts
+description: Expanded information on how Litmus works.
+---
+
+
+The main engineering goal of Litmus is to re-use as much existing content and external code as is feasible.
+Smaller re-usable components and leveraging functionality of other projects allows for easier adaptation and allows Litmus to ride along on the success of others, like bolt.
+It also means that it is easier to replace the parts that did not turn out to fulfill the needs of the users.
+
+## Components
+
+The following list is the current set of components and implementation choices. Some of those choices are pure expediency to get something working. Others clear strategic decisions to build a better-together story.
+
+* UI: litmus rake tasks
+* Communication Layer: bolt
+* Configuration:
+  * `provision.yaml`
+  * CI job setup
+  * `spec/fixtures/litmus_inventory.yaml`
+  * test dependencies: .fixtures.yml
+* Test Infrastructure:
+  * puppetlabs-provision module
+  * hypervisors: docker, vagrant, vmpooler, abs
+  * external provisioners: e.g. terraform
+  * test systems:
+    * litmusimage
+    * upstream images
+    * custom images
+* utility code
+  * puppetlabs-facts module
+  * puppetlabs-puppet_agent module
+* Test Tracing: honeycomb
+* Testing System
+  * runner: RSpec
+  * test case definition: RSpec
+  * test setup:
+    * a manifest string embedded in the test case
+    * ruby code to orchestrate a change
+  * test assertion
+    * serverspec
+    * hand-coded checks
+* Packaging and delivery:
+  * Litmus as gem
+  * Litmus as PDK component
+  * utility modules as git repos
+  * bolt as gem
+
+The following sections go over the various components, their reasoning and discuss alternative options.
+
+## UI
+
+The current UI/UX of Litmus is implemented as a set of rake tasks in [puppet_litmus:lib/puppet_litmus/rake_tasks.rb](https://github.com/puppetlabs/puppet_litmus/blob/master/lib/puppet_litmus/rake_tasks.rb).
+
+**Reasoning:**
+Rake is a ubiquitous choice of interacting with a set of connected tasks in the ruby world.
+The limited option parsing capabilities push the design towards simple interactions and storing important information in configuration files.
+It is very easy to get started with a project based on rake tasks, as there is a wealth of examples and tutorials on how to build rake tasks.
+
+**Alternatives:**
+As the Litmus workflow and configuration matures we might want to consider a dedicated CLI with more ergonomic option parsing possibilities.
+This could be implemented as part of the pdk (`pdk test acceptance`) or a standalone CLI tool shipped as part of the PDK.
+
+The VSCode plugin could provide additional UI to make running and interacting with acceptance tests directly from the IDE possible.
+
+## Communication Layer
+
+The communications layer for litmus needs to be able to talk to all the various systems that users might want to use in testing.
+
+**Reasoning:**
+Bolt supports SSH, WinRM natively and allows extension to other remote protocols using Puppet's extension points.
+With Bolt being integrated into our entire product line, re-using it also for content testing is an easy choice.
+Content generated for Bolt can be re-used within tests, and vice versa.
+This allows users to re-use skills acquired and strenghtens Puppet's better-together story.
+
+**Alternatives:**
+Bolt as communication layer touches most other components and - while having a well-defined interface - would not be easy to replace.
+There is currently no reason to consider alternatives to Bolt.
+
+## Configuration
+
+Configuration for Litmus currently is spread over several files.
+The `provision.yaml` contains various lists of platforms to target for tests.
+The CI job setup (usually in `.travis.yml`, `appveyor.yml` or similar) contains the overall sequencing of steps for testing.
+This setup is usually the same everywhere and is encoded in pdk-templates.
+There are slight variations to choose the puppet version and platform combinations from `provision.yaml`.
+
+Last but not least, transient state and roles of provisioned systems is stored in Bolt's `inventory.yaml`.
+The inventory is usually managed by Litmus as an implementation detail.
+In advanced scenarios users can create, add, edit, or replace the inventory in pursuit of their use cases.
+
+**Reasoning:**
+The current set of configurations is the absolute minimum to get Litmus working.
+Most of the files are inherited from existing practices and tools.
+
+**Alternatives:**
+While the current set of configuration files works for now, it's main purpose is to carry Litmus over this phase and highlight the requirements for the next iteration.
+* Replace scattered configuration with a [Boltdir](https://puppet.com/docs/bolt/latest/bolt_project_directories.html) that can contain all the module-specific info required
+  * Replace .fixtures.yml with `Boltdir/Puppetfile` for unit and acceptance testing
+  * Investigate/implement pdk/litmus specific `Boltdir` location/name to avoid colliding with production use of a Boltdir
+  * Get test-hiera data/config from `Boltdir/data` by default
+
+* The current setup of (re-)writing the inventory is problematic as it deprives advanced users of safe ways to enhance the inventory to suit their needs
+  * Example: custom SSH key/options
+  * Bolt has now plugins to receive inventory information from outside sources - would this be a good way to keep dynamic litmus data out of inventory.yaml?
+
+* Find ways to pass arguments to provisioners
+  * Hypervisor Credentials and arguments
+  * bolt options (e.g custom SSH key/options)
+  * which parts of this are module/repo specific? which parts need to be per-user?
+
+
+## Test Infrastructure
+
+For full system-level testing of acceptance criteria, tests require access to systems to test.
+Depending on the use-case and resources available, this test infrastructure can be accessed in a variety of ways.
+There are a few necessary conditions for all those test systems:
+* accessible through bolt - this allows tests to act on such a system
+* initially clean - without a well-defined initial state, tests become complex, unreliable, or both
+* dedicated - running tests on shared systems is inviting troubles, either by tests stepping on each other or the tests interfering with user activities or the other way around
+* representative of production systems - running the tests should provide insight about expected behaviour in the real world
+
+### What can be used as Test Infrastructure?
+
+Throw-away VMs are the easiest way to fulfil those conditions.
+Provisioned from upstream images or organisations' golden templates,
+they provide a complete operating system, accurate representation of production and full isolation.
+The downside of virtual machines are the high resource usage and provisioning times in the order of minutes.
+You can use local VMs on your development workstation, or private and public cloud providers.
+
+To reduce resource usage and provisioning times docker and containers come in handy.
+They deploy in seconds and achieve high packing densities with low overhead.
+Best practices for container images justifiably frowns on SSH access or complete operating system services,
+thus common public images are usually not representative of production on full VMs.
+To avoid this limitation, [puppetlabs/litmusimages](https://github.com/puppetlabs/litmusimage) provides a set of pre-fabbed [docker images](https://hub.docker.com/u/litmusimage) that allow SSH access and have an init process running.
+
+In some cases, using bare metal servers or already running systems is unavoidable.
+
+### How to provision Test Infrastructure
+
+There are as many ways to aqcuire access to test systems as there are kinds of test systems.
+By default, Litmus calls out to a provisioner task to provision or tear down systems on demand.
+In the `puppetlabs-provision` module, we ship a number of commonly needed provisioners for docker (with SSH), docker_exp (using bolt's docker transport), vagrant (for local VMs) and the private cloud APIs [VMpooler](https://github.com/puppetlabs/vmpooler) and the puppet-private [ABS](https://github.com/puppetlabs/always-be-scheduling).
+
+Since Litmus 0.18 the rake tasks also allow calling arbitrary tasks outside the `provision` module to provision test systems. [Daniel's terraform demo](https://youtu.be/8BMo9DcZ4-Q) shows one application of this.
+
+The provision task will allocate/provision/start VMs or containers of the requested platforms and add them to the `spec/fixtures/litmus_inventory.yaml` file.
+
+Through the use of the inventory file Litmus can also consume arbitrary other systems by users supplying their own data, independently of Litmus' provision capabilities.
+
+### Alternatives
+
+There are a number of opportunities to improve today's provision capabilities.
+
+* image customisation:
+  To make images usable with litmus, some customisation and workarounds need to be applied.
+  Be that installing SSH (litmusimage), removing tty handling (`fix_missing_tty_error_message`), configuring root access (`docker` provisioner), configure sudo access (`vagrant` provisioner) or installing pre-reqs to install the agent (`wget`/`curl`/etc).
+  These workarounds are distributed across different components at the moment.
+  Collecting all of them into the image baking process (litmusimage) would
+  * make the provisioning code path easier and faster
+  * allow users to discover litmus' requirements for custom images by inspecting the litmusimage build process
+  * reduce "magic" happenings when using custom images
+
+* move inventory manipulation from provisioning tasks to litmus:
+  Currently provisioning tasks are required to update the `spec/fixtures/litmus_inventory.yaml` file with new target information and remove targets from the `spec/fixtures/litmus_inventory.yaml` file on tear down.
+  This causes a number of problems:
+  * code duplication
+  * prohibits running provisioners in parallel
+  * unnecessarily pushes some operations (see `vars` handling) into provision tasks
+  * requires provision tasks to run on the caller's host
+  Instead of writing directly to `spec/fixtures/litmus_inventory.yaml` file the provision tasks could return bolt transport configuration as part of the task result data.
+  Litmus could then process that data as required in the work flow.
+  Provisioners could now run in parallel and Litmus can coalesce the data at the end into a `spec/fixtures/litmus_inventory.yaml` file.
+  This approach requires only minimal code in the task (return data as JSON).
+
+* allow more granular data than the platform name:
+  Some provisioners could benefit from additional parameters passed in.
+  For example choosing a specific AWS zone, VPC, GCP project or tags to host the test systems.
+  This change also interacts with changes to how configuration data is stored. See 'Configuration' section above.
+
+## Utility Code
+
+Litmus makes use of the [`puppetlabs-facts`](https://github.com/puppetlabs/puppetlabs-facts) and [`puppetlabs-puppet_agent`](https://github.com/puppetlabs/puppetlabs-puppet_agent) modules for some key operations.
+
+**Reasoning:**
+These modules are maintained and used in other parts of the ecosystem already.
+Reusing them provides for a consistent behaviour across different products and additional value gained from the existing development and maintenance effort.
+
+**Alternatives:**
+None required at the moment.
+
+## Test Tracing
+
+For puppet-internal use we have instrumented Litmus and RSpec with [Honeycomb](https://honeycomb.io).
+This is a optional component that is deactivated by default.
+
+**Reasoning:**
+As the IAC team is maintaining ~50 modules' test suites across Travis CI, Appveyor and Github Actions, we were looking for a unified way to keep track of everything that is going on.
+While not originally designed for it, Honeycomb fit the bill easily.
+
+**Alternatives:**
+None required at the moment.
+
+## Testing System
+
+This section covers all the things concerned with defining and executing the test cases.
+
+### Test Runner
+
+RSpec is a mature and widely used unit-testing framework in the Ruby Ecosystem.
+We are maintaining mature integrations for Puppet catalog-level unit testing and there is a rich ecosystem of adjacent tooling by the puppet community.
+
+**Rationale:**
+Using an existing product keeps us from re-inventing the wheel.
+RSpec has a host of already built in features and an ecosystem of plugins as well as tutorials and documentation.
+We've been able to adapt RSpec to our needs by using existing extension points.
+RSpec allows for fine-grained and dynamic test-selection, and provides excellent feedback to the user.
+
+**Alternatives:**
+None required at the moment.
+
+### Test Case Definition
+
+While RSpec's fine-grained test setup capabilities are very necessary and useful for unit testing, the same capabilities have reduced applicability when looking at acceptance testing.
+These system-level tests usually have a lot more setup requirements and fewer, but more specialised tests.
+
+**Rationale:**
+RSpec test case definition language was chosen by default as part of the RSpec test runner in the early stages of the evolution of Puppet test practices.
+
+**Alternatives:**
+For a while [cucumber-puppet](https://github.com/petems/cucumber-puppet) was developed by some as an alternative but never gained as much traction or support in the Puppet community.
+
+### Test Setup
+
+The test setup describes the necessary steps to reach the state to test.
+In litmus this is currently implemented by a mix of manifest strings embedded in ruby and litmus' ruby DSL calls.
+
+**Rationale:**
+This style of test setup is inherited from beaker-rspec and "The RSpec Way".
+
+**Alternatives:**
+Creating RSpec extensions for acceptance testing - like rspec-puppet does for unit testing - to represent common patterns would allow for crisper test setup definition.
+The additional abstraction could allow for more clarity and efficiency in setting up tests.
+
+### Test Assertion
+
+After a test scenario is set up, assertions are executed to understand whether or not the original expectations are met.
+This can be as simple as checking a file's content to as complex as interacting with an API to check its behaviour.
+
+In acceptance tests the first way to check a system's target state is idempotency.
+This is implemented as first-class operation `idempotent_apply` in the Litmus DSL.
+
+To ascertain that a service is not only working, but also correctly configured more in-depth checks need to be implemented in ruby.
+[serverspec](https://serverspec.org/) is preconfigured inside Litmus to allow for checking a number of common resources.
+
+Other checks can be implemented in plain ruby or RSpec as required.
+
+#### Rationale
+
+Tests derive value from being easier to understand than the code under test. Through this they provide a confidence that merely reading the business logic (or, in Litmus' case the manifest) does not support.
+
+If puppet runs the same manifest a second time without errors or changes, this already implies that the desired system state has been reached.
+In many cases - for example when managing services - this is a more in-depth check that a test could do on its own.
+A service starting up and staying running implies that its configuration was valid and consistent.
+This is a check that would be very hard, nay prohibitively expensive, to implement in a test.
+Idempotency checking makes this (almost) free.
+
+Serverspec was created for acceptance testing infrastructure.
+It integrates nicely with RSpec.
+Serverspec provides [resources and checks](https://serverspec.org/resource_types.html) that are currently not expressible in puppet code, like "port should be listening" or partial matching on file contents.
+
+#### Alternatives
+
+* [Chef's InSpec](https://www.inspec.io/) was forked from serverspec and developed by Chef.
+* [Selenium](https://www.selenium.dev/) automates browsers and arguably could be used to check the health of a service deployed for testing.
+* Any kind of monitoring or application-level testing framework that is already used for a specific service could be used to create insight into the health of said service.
+
+## Packaging and Delivery
+
+* Litmus is currently released as a gem first.
+
+  **Rationale:**
+  In this phase of development this allows for rapid iteration.
+  Deploying gems is well-understood in the development community.
+
+* Litmus is also shipped as part of the PDK.
+
+  **Rationale:**
+  As an experimental part of the PDK Litmus becomes available offline to those who otherwise would need to cross air-gaps.
+  At the same time, this also ensures that all the required dependencies are available in a PDK installation.
+  Specifically this also would notify us if Litmus adds a dependency that is not compatible with the PDK runtime.
+
+* The Utility Modules are currently by default deployed into a test run directly from github.
+
+  **Rationale:**
+  Expediency and speed.
+
+  **Alternatives:**
+  To avoid poisoning test environments with litmus' implementation details and better support offline work,
+  the utility modules should be packaged up as part of the litmus gem and sourced from a private modulepath when needed.
+  Grouping all content in that way enhances confidence that it is a fully tested package.
+  This would also require more integrated testing and more frequent litmus releases to make changes available.
+
+* bolt is currently consumed as a gem
+
+  **Rationale:**
+  Litmus is tightly bound to specific internal APIs and its dependencies.
+  Depending on a gem provides flexibility in consuming bolt updates as Litmus is ready for it.
+  Using the gem avoids any environmental dependencies and support issues arising from version mismatches.
+
+  **Alternatives:**
+  Require bolt to be installed from its package.

--- a/docs/md/content/usage/_index.md
+++ b/docs/md/content/usage/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Usage"
+description: "Learn how to use litmus."
+weight: 100
+skipTerminal: true
+---

--- a/docs/md/content/usage/commands/_index.md
+++ b/docs/md/content/usage/commands/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Commands"
+description: "Learn the Litmus commands."
+weight: 100
+skipTerminal: true
+---

--- a/docs/md/content/usage/commands/command-reference.md
+++ b/docs/md/content/usage/commands/command-reference.md
@@ -1,0 +1,54 @@
+---
+layout: page
+title: Command reference
+description: List of useful Litmus commands.
+---
+
+### Debug
+
+Litmus has the ability to display more information when it is running, this can help you diagnose some issues. 
+
+```
+export DEBUG=true
+```
+
+### Useful Docker commands
+
+To list all docker images, including stopped ones, run:
+```
+docker ps -a
+```
+
+You will get output similar to:
+
+```
+docker container ls -a
+CONTAINER ID        IMAGE                      COMMAND                  CREATED              STATUS                     PORTS                  NAMES
+e7bc7e5b3d9b        litmusimage/oraclelinux7   "/bin/sh -c /usr/sbi…"   About a minute ago   Up About a minute          0.0.0.0:2225->22/tcp   litmusimage_oraclelinux7_-2225
+ae94def06077        litmusimage/oraclelinux6   "/bin/sh -c /sbin/in…"   3 minutes ago        Up 3 minutes               0.0.0.0:2224->22/tcp   litmusimage_oraclelinux6_-2224
+80b22735494e        litmusimage/centos6        "/bin/sh -c /sbin/in…"   5 minutes ago        Up 5 minutes               0.0.0.0:2223->22/tcp   litmusimage_centos6_-2223
+b7923a25f95b        ubuntu:14.04               "/bin/bash"              6 weeks ago          Exited (255) 4 weeks ago   0.0.0.0:2222->22/tcp   ubuntu_14.04-2222
+```
+
+To stop and remove an image, run:
+
+```
+docker rm -f ubuntu_14.04-2222
+```
+
+To connect via ssh to the Docker image, run:
+
+```
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@localhost -p 2222
+```
+
+Note that you don't need to add to the known hosts file or check keys.
+
+To attach to the docker image and detach, run:
+
+```
+docker attach centos6
+ to deattach <ctrl + p> then <ctrl + q>
+```
+
+Note that you cannot attach to a Docker image that is running systemd/upstart, for example, the `litmus_image` images.

--- a/docs/md/content/usage/commands/litmus-core-commands.md
+++ b/docs/md/content/usage/commands/litmus-core-commands.md
@@ -1,0 +1,250 @@
+---
+layout: page
+title: Core commands
+description: Learn Litmus core commands.
+---
+
+Using the Litmus commands, you can provision test platforms such as containers/images, install a Puppet agent, install a module and run tests.
+
+Litmus has five commands:
+
+1. [Provision: 'rake litmus:provision'](#provision)
+2. [Install the agent: 'rake litmus:install_agent](#agent)
+3. [Install the module: 'rake litmus:install_module'](#module)
+4. [Run the tests: 'rake litmus:acceptance:parallel'](#test)
+5. [Remove the provisioned machines: 'rake litmus:tear_down'](#teardown)
+
+These commands allow you to create a test environment and run tests against your systems. Note that not all of these steps are needed for every deployment.
+
+Three common test setups are:
+  * Run against localhost
+  * Run against an existing machine that has Puppet installed
+  * Provision a fresh system and install Puppet
+
+Once you have your environment, Litmus is designed to speed up the following workflow:
+
+```
+edit code -> install module -> run test
+```
+
+At any point you can re-run tests, or provision new systems and add them to your test environment.
+
+<a name="provision"/>
+
+## Provisioning
+
+Using the Litmus [provision](https://github.com/puppetlabs/provision) command, you can spin up Docker containers, vagrant boxes or VMs in private clouds, such as vmpooler.
+
+For example:
+
+```
+pdk bundle exec rake 'litmus:provision[vmpooler, redhat-6-x86_64]'
+pdk bundle exec rake 'litmus:provision[docker, litmusimage/ubuntu:18.04]'
+pdk bundle exec rake 'litmus:provision[vagrant, gusztavvargadr/windows-server]'
+```
+
+> Note: Provisioning is extensible — if your chosen provisioner isn't available, you can add your own provisioner task to your test set up through a separate module in `.fixtures.yml`.
+
+The provision command creates a Bolt `spec/fixtures/litmus_inventory.yml` file for Litmus to use. You can manually add machines to this file.
+
+For example:
+
+```yaml
+---
+version: 2
+groups:
+- name: docker_nodes
+  targets: []
+- name: ssh_nodes
+  targets:
+  - uri: localhost:2222
+    config:
+      transport: ssh
+      ssh:
+        user: root
+        password: root
+        port: 2222
+        host-key-check: false
+    facts:
+      provisioner: docker
+      container_name: centos_7-2222
+      platform: centos:7
+- name: winrm_nodes
+  targets: []
+```
+
+For more examples of inventory files, see the [Bolt documentation](https://puppet.com/docs/bolt/latest/inventory_file_v2.html).
+
+Note that you can test some modules against localhost — the machine you are running your test from. Note that this is only recommended if you are familiar with the code base, as tests may have unexpected side effects on your local machine. To run a test against localhost, see [Run the tests: 'rake litmus:parallel'](#test)
+
+### Testing services
+
+For testing services that require a service manager (like systemd), the default Docker images might not be enough. In this case, there is a collection of Docker images, with a service manager enabled, based on https://github.com/puppetlabs/litmusimage. For available images, see the [docker hub](https://hub.docker.com/u/litmusimage).
+
+Alternatively, you can use a dedicated VM that uses another provisioner, for example vmpooler or vagrant.
+
+### Provisioning via YAML
+
+In addition to directly provisioning one or more machines using `litmus:provision`, you can also define one or more sets of nodes in a `provision.yaml` file and use that to provision targets.
+
+An example of a `provision.yaml` defining a single node:
+
+```yaml
+---
+list_name:
+  provisioner: vagrant
+  images: ['centos/7', 'generic/ubuntu1804', 'gusztavvargadr/windows-server']
+  params:
+    param_a: someone
+    param_b: something
+```
+
+Take note of the following:
+
+- The `list_name` is arbitrary and can be any string you want.
+- The `provisioner` specifies which provision task to use.
+- The `images` must specify an array of one or more images to provision.
+- Any keys inside of `params` will be turned into process-scope environment variables as the key, upcased. In the example above, `param_a` would become an environment variable called `PARAM_A` with a value of `someone`.
+
+An example of a `provision.yaml` defining multiple nodes:
+
+```yaml
+---
+---
+default:
+  provisioner: docker
+  images: ['litmusimage/centos:7']
+vagrant:
+  provisioner: vagrant
+  images: ['centos/7', 'generic/ubuntu1804', 'gusztavvargadr/windows-server']
+travis_deb:
+  provisioner: docker
+  images: ['litmusimage/debian:8', 'litmusimage/debian:9', 'litmusimage/debian:10']
+travis_ub:
+  provisioner: docker
+  images: ['litmusimage/ubuntu:14.04', 'litmusimage/ubuntu:16.04', 'litmusimage/ubuntu:18.04']
+travis_el6:
+  provisioner: docker
+  images: ['litmusimage/centos:6', 'litmusimage/oraclelinux:6', 'litmusimage/scientificlinux:6']
+travis_el7:
+  provisioner: docker
+  images: ['litmusimage/centos:7', 'litmusimage/oraclelinux:7', 'litmusimage/scientificlinux:7']
+release_checks:
+  provisioner: vmpooler
+  images: ['redhat-5-x86_64', 'redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-5-x86_64', 'centos-6-x86_64', 'centos-7-x86_64', 'centos-8-x86_64', 'oracle-5-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'debian-10-x86_64', 'sles-11-x86_64', 'sles-12-x86_64', 'sles-15-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64', 'win-2008r2-x86_64', 'win-2012r2-x86_64', 'win-2016-core-x86_64', 'win-2019-core-x86_64', 'win-10-pro-x86_64']
+```
+
+You can then provision a list of targets from that file:
+
+```bash
+# This will spin up all the nodes defined in the `release_checks` key via VMPooler
+pdk bundle exec rake 'litmus:provision_list[release_checks]'
+# This will spin up the three nodes listed in the `vagrant` key via Vagrant.
+# Note that it will also turn the listed key-value pairs in `params` into
+# the environment variables and enable the task to leverage them.
+pdk bundle exec rake 'litmus:provision_list[vagrant]'
+```
+
+<a name="agent"/>
+
+## Installing a Puppet agent
+
+Install an agent on the provisioned targets using the [Puppet Agent module](https://github.com/puppetlabs/puppetlabs-puppet_agent). The tasks in this module allow you to install different versions of the Puppet agent, on  different OSes.
+
+Use the following command to install an agent on a single target or on all the targets in the `spec/fixtures/litmus_inventory.yaml` file. Note that agents are installed in parallel when running against multiple targets.
+
+Install an agent on a target using the following commands:
+
+```
+# Install the latest Puppet agent on a specific target
+pdk bundle exec rake 'litmus:install_agent[gn55owqktvej9fp.delivery.puppetlabs.net]'
+
+# Install the latest Puppet agent on all targets
+pdk bundle exec rake "litmus:install_agent"
+
+# Install Puppet 5 on all targets
+pdk bundle exec rake 'litmus:install_agent[puppet5]'
+
+```
+
+<a name="module"/>
+
+## Installing a module
+
+Using PDK and Bolt, the `rake litmus:install_module` command builds and installs a module on the target.
+
+For example:
+
+```
+pdk bundle exec rake "litmus:install_module"
+```
+
+If you need multiple modules on the target system (e.g. fixtures pulled down through `pdk bundle exec rake spec_prep`, or a previous unit test run):
+
+```
+pdk bundle exec rake "litmus:install_modules_from_directory[spec/fixtures/modules]"
+```
+
+<a name="test"/>
+
+## Running tests
+
+There are several options for running tests. Litmus primarily uses [serverspec](https://serverspec.org/), though you can use other testing tools.
+
+When running tests with Litmus, you can:
+* Run all tests against a single target.
+* Run all tests against all targets in parallel.
+* Run a single test against a single target.
+
+An example running all tests against a single target:
+
+```
+# On Linux/MacOS:
+TARGET_HOST=lk8g530gzpjxogh.delivery.puppetlabs.net pdk bundle exec rspec ./spec/acceptance
+TARGET_HOST=localhost:2223 pdk bundle exec rspec ./spec/acceptance
+# On Windows:
+$ENV:TARGET_HOST = 'lk8g530gzpjxogh.delivery.puppetlabs.net'
+pdk bundle exec rspec ./spec/acceptance
+```
+
+An example running a specific test against a single target:
+
+```
+# On Linux/MacOS:
+TARGET_HOST=lk8g530gzpjxogh.delivery.puppetlabs.net pdk bundle exec rspec ./spec/acceptance/test_spec.rb:21
+TARGET_HOST=localhost:2223 pdk bundle exec rspec ./spec/acceptance/test_spec.rb:21
+# On Windows:
+$ENV:TARGET_HOST = 'lk8g530gzpjxogh.delivery.puppetlabs.net'
+pdk bundle exec rspec ./spec/acceptance/test_spec.rb:21
+```
+
+An example running all tests against all targets, as specified in the `spec/fixtures/litmus_inventory.yaml` file:
+
+```
+pdk bundle exec rake litmus:acceptance:parallel
+```
+
+An example running all tests against localhost. Note that this is only recommended if you are familiar with the code base, as tests may have unexpected side effects on your local machine.
+
+```
+pdk bundle exec rake litmus:acceptance:localhost
+```
+
+For more test examples, see [run_tests task](https://github.com/puppetlabs/provision/wiki#run_tests) or [run tests plan](https://github.com/puppetlabs/provision/wiki#tests_against_agents)
+
+<a name="teardown"/>
+
+## Removing provisioned systems
+
+Use the commands below to clean up provisioned systems after running tests. Specify whether to to remove an individual target or all the targets in the `spec/fixtures/litmus_inventory.yaml` file.
+
+```
+# Tear down a specific target vm
+pdk bundle exec rake "litmus:tear_down[c985f9svvvu95nv.delivery.puppetlabs.net]"
+
+# Tear down a specific target running locally
+pdk bundle exec rake "litmus:tear_down[localhost:2222]"
+
+# Tear down all targets in `spec/fixtures/litmus_inventory.yaml` file
+pdk bundle exec rake "litmus:tear_down"
+```

--- a/docs/md/content/usage/converting-modules-to-use-Litmus.md
+++ b/docs/md/content/usage/converting-modules-to-use-Litmus.md
@@ -1,0 +1,76 @@
+---
+layout: page
+title: Quick Start Guide
+description: Learn how to use Litmus in your Puppet modules.
+weight: 1
+---
+
+The following example walks you through enabling Litmus testing in a module.
+
+The process involves editing or adding code to the following files:
+
+1. The `Gemfile`
+2. The `Rakefile`
+3. The`.fixtures.yml` file
+4. The `spec_helper_acceptance.rb` file
+5. The `spec_helper_acceptance_local.rb` file
+
+## Before you begin
+
+This guide assumes your module is compatible with [Puppet Development Kit (PDK)](https://puppet.com/docs/pdk/1.x/pdk.html),
+meaning it was either created with `pdk new module` or has been converted to use PDK using the `pdk convert` command.
+To verify that your module is compatible with PDK, look in the modules `metadata.json` file and see whether there is an entry that states the PDK version.
+It will look something like `"pdk-version": "1.18.0"`.
+The PDK ships litmus as an experimental component.
+
+To enable it, follow the steps below.
+
+## 1. Add required development dependencies
+
+Inside the root directory of your module, add the following entries to the `.fixtures.yml`:
+
+```yaml
+---
+fixtures:
+  repositories:
+    facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
+    provision: 'https://github.com/puppetlabs/provision.git'
+```
+
+## 2. Create the `spec/spec_helper_acceptance.rb` file
+
+Inside the `spec` folder of the module, create a `spec_helper_acceptance.rb` file with the following contents:
+
+```ruby
+# frozen_string_literal: true
+
+require 'puppet_litmus'
+PuppetLitmus.configure!
+
+require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))
+```
+
+This file will later become managed by the PDK. For local changes, see the next step.
+
+## 3. Create the `spec/spec_helper_acceptance_local.rb` file
+
+***Optional:*** For module-specific methods to be used during acceptance testing, create a `spec/spec_helper_acceptance_local.rb` file. This will be loaded at the start of each test run. If you need to use any of the Litmus methods in this file, include Litmus as a singleton class:
+
+```ruby
+# frozen_string_literal: true
+require 'singleton'
+
+class Helper
+  include Singleton
+  include PuppetLitmus
+end
+
+def some_helper_method
+  Helper.instance.bolt_run_script('path/to/file')
+end
+```
+
+## 4. Add tests to `spec/acceptance`
+
+You can find [litmus test examples](/content-and-tooling-team/docs/litmus/usage/testing/litmus-test-examples/) on their own page.

--- a/docs/md/content/usage/litmus-helper-functions.md
+++ b/docs/md/content/usage/litmus-helper-functions.md
@@ -1,0 +1,11 @@
+---
+title: Helper functions
+layout: page
+description: Learn all about Litmus functions.
+---
+
+Inside of the Litmus gem, there are three distinct sets of functions:
+
+*  Rake tasks for the CLI that allows you to use the Litmus commands (provision, install an agent, install a module and run tests.). Run `pdk bundle exec rake -T` to get a list of available rake tasks.
+* Helper functions for serverspec / test. These apply manifests or run shell commands. For more information, see [Puppet Helpers](https://www.rubydoc.info/gems/puppet_litmus/PuppetLitmus/PuppetHelpers)
+* Helper Functions for Bolt inventory file manipulation. For more information, see [Inventory Manipulation](https://www.rubydoc.info/gems/puppet_litmus/PuppetLitmus/InventoryManipulation).

--- a/docs/md/content/usage/testing/_index.md
+++ b/docs/md/content/usage/testing/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Testing"
+description: "Learn how to test with Litmus."
+weight: 100
+skipTerminal: true
+---

--- a/docs/md/content/usage/testing/litmus-test-examples.md
+++ b/docs/md/content/usage/testing/litmus-test-examples.md
@@ -1,0 +1,91 @@
+---
+layout: page
+title: Example tests
+description: A list of example Litmus tests.
+---
+
+These are some common examples you can use in your tests. Take note of the differences between beaker-rspec style testing and Litmus.
+
+## Testing Puppet code
+
+The following example tests that your Puppet code works. Take note of the repeatable pattern.
+
+```ruby
+require 'spec_helper_acceptance'
+
+describe 'a feature', if: ['debian', 'redhat', 'ubuntu'].include?(os[:family]) do
+  let(:pp) do
+    <<-MANIFEST
+      include feature::some_class
+    MANIFEST
+  end
+
+  it 'applies idempotently' do
+    idempotent_apply(pp)
+  end
+
+  describe file("/etc/feature.conf") do
+    it { is_expected.to be_file }
+    its(:content) { is_expected.to match %r{key = default value} }
+  end
+
+  describe port(777) do
+    it { is_expected.to be_listening }
+  end
+end
+```
+
+## Testing manifest code for idempotency
+
+The `idempotent_apply` helper function runs the given manifest twice and will test that the first run doesn't have errors and the second run doesn't have changes. For many regular modules that already will give good confidence that it is working:
+
+```ruby
+pp = 'class { "mysql::server": }'
+idempotent_apply(pp)
+```
+
+## Running shell commands
+
+To run a shell command and test it's output:
+
+```ruby
+expect(run_shell('/usr/local/sbin/mysqlbackup.sh').stderr).to eq('')
+```
+
+### Serverspec Idioms
+
+An example of a serverspec declaration:
+
+```ruby
+describe command('/usr/local/sbin/mysqlbackup.sh') do
+  its(:stderr) { should eq '' }
+end
+```
+
+## Checking facts
+
+With Litmus, you can use the serverspec functions — these are cached so are quick to call. For example:
+
+```ruby
+os[:family]
+```
+
+or
+
+```ruby
+host_inventory['facter']['os']['release']
+```
+
+For more information, see the [serverspec docs](https://serverspec.org/host_inventory.html).
+
+## Debugging tests
+
+There is a known issue when running certain commands from within a pry session. To debug tests, use the following pry-byebug gem:
+
+```ruby
+gem  'pry-byebug', '> 3.4.3'
+```
+
+## Setting up Travis and Appveyor
+
+To see this running on CI, enable the `use_litmus` flags for Travis CI and/or Appveyor. See the [pdk-templates docs](https://github.com/puppetlabs/pdk-templates#travisyml) for details and additional options.

--- a/docs/md/content/usage/testing/running-acceptance-tests.md
+++ b/docs/md/content/usage/testing/running-acceptance-tests.md
@@ -1,0 +1,252 @@
+---
+layout: page
+title: Acceptance tests
+description: Acceptance testing with Litmus.
+---
+
+The following example walks you through running an acceptance test on the [MoTD](https://github.com/puppetlabs/puppetlabs-motd) module.
+
+The process involves these steps:
+
+1. Clone the MoTD module from GitHub.
+1. Provision a CentOS Docker image.
+1. Install a Puppet 6 agent on the CentOS image.
+1. Install the MoTD module on the CentOS image.
+1. Run the MoTD acceptance tests.
+1. Remove the Docker image.
+
+## Before you begin
+
+Ensure you have installed the following:
+
+* [Docker](https://runnable.com/docker/getting-started/).
+	* To check whether you already have Docker, run `docker --version` from the command line.
+	* To check Docker is working, run `docker run centos:7 ls` in your terminal. You should see a list of folders in the CentOS image.
+* [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+	* To check  where you already have git, run `git --version` in your terminal.
+* [Puppet Development Kit (PDK)](https://puppet.com/docs/pdk/1.x/pdk_install.html).
+	* To check whether you already have PDK, run `pdk --version` from the command line. Note that you need version `1.17.0` or later. If not, then following the [installation instructions](https://puppet.com/docs/pdk/1.x/pdk_install.html).
+
+
+## 1. Clone the MoTD module from GitHub.
+
+From  the command line, clone the Litmus branch of MoTD module:
+```
+git clone https://github.com/puppetlabs/puppetlabs-motd.git
+```
+You now have a local copy of the module on your machine. In this example, you can work  off the master branch.
+
+Change directory to the MoTD module
+```
+cd puppetlabs-motd
+```
+
+
+## 2. Install the necessary gems.
+
+The MoTD module relies on a number of gems. To install these on your machine, run the following command:
+
+```
+pdk bundle install
+```
+
+
+## 3. Provision a CentOS Docker image.
+
+Provision a CentOS 7 image in a Docker container to be the target you will test against
+
+To provision the CentOS 7 target (or any OS of your choice), run the following command:
+
+```
+pdk bundle exec rake 'litmus:provision[docker, litmusimage/centos:7]'
+```
+
+> Note: Provisioning is extensible. If your preferred provisioner is missing, let us know by raising an issue on the [provision repo](https://github.com/puppetlabs/provision/issues) or submitting a [PR](https://github.com/puppetlabs/provision/pulls).
+
+The last lines of the output should look like:
+
+```
+Provisioning centos:7 using docker provisioner.[✔]
+localhost:2222, centos:7
+```
+
+To check that it worked, run `docker ps` and you should see output similar to:
+
+```
+CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                  NAMES
+7b12b616cf65        centos:7            "/bin/bash"         4 minutes ago       Up 4 minutes        0.0.0.0:2222->22/tcp   centos_7-2222
+```
+
+Note that the provisioned targets will be in the `spec/fixtures/litmus_inventory.yaml` file. Litmus creates this file in your working directory. If you run `cat spec/fixtures/litmus_inventory.yaml`, you should see the targets you just created. For example:
+
+```yaml
+# litmus_inventory.yaml
+---
+version: 2
+groups:
+- name: docker_nodes
+  targets: []
+- name: ssh_nodes
+  targets:
+  - uri: localhost:2222
+    config:
+      transport: ssh
+      ssh:
+        user: root
+        password: root
+        port: 2222
+        host-key-check: false
+    facts:
+      provisioner: docker
+      container_name: centos_7-2222
+      platform: centos:7
+- name: winrm_nodes
+  targets: []
+```
+
+## 4. Install Puppet agent on your target
+
+To install the latest version of Puppet agent on the CentOS Docker image, run the following command:
+
+```
+pdk bundle exec rake litmus:install_agent
+```
+
+Use Bolt to verify that you have installed the agent on the target. Run the following command:
+
+```
+pdk bundle exec bolt command run 'puppet --version' --targets localhost:2222 --inventoryfile spec/fixtures/litmus_inventory.yaml
+```
+
+Note that `localhost:2222` is the name of the node in the spec/fixtures/litmus_inventory.yaml file. You should see output with the version of the Puppet agent that was installed:
+
+```
+bolt command run 'puppet --version' --targets localhost:2222 --inventoryfile spec/fixtures/litmus_inventory.yaml
+```
+
+Running the command will produce output similar to this:
+
+```
+Started on localhost:2222...
+Finished on localhost:2222:
+  STDOUT:
+    6.13.0
+Successful on 1 target: localhost:2222
+Ran on 1 target in 1.72 sec
+```
+
+If you want to install a specific version of puppet you can use the following command:
+```
+pdk bundle exec rake 'litmus:install_agent[puppet6]
+```
+Examples of other versions you can pass in are: puppet6-nightly, puppet7, puppet7-nightly.
+
+
+## 5. Install the MoTD module on the CentOS image.
+
+To install the MoTD module on the CentOS image, run the following command from inside your working directory:
+
+```
+pdk bundle exec rake litmus:install_module
+```
+
+*Note: If you are interactively modifying code and testing, this step must be run after your changes are made and before you run your tests.*
+
+You will see output similar to:
+
+```
+➜  puppetlabs-motd git:(main) pdk bundle exec rake litmus:install_module
+pdk (INFO): Using Ruby 2.6.3
+pdk (INFO): Using Puppet 7.7.0
+Building '/Users/paula/workspace/puppetlabs-mysql' into '/Users/paula/workspace/puppetlabs-motd/pkg'
+Built '/Users/paula/workspace/puppetlabs-motd/pkg/puppetlabs-motd-11.0.3.tar.gz'
+Installed '/Users/paula/workspace/puppetlabs-motd/pkg/puppetlabs-motd-11.0.3.tar.gz' on
+```
+
+Use Bolt to verify that you have installed the MoTD module. Run the following command:
+
+```
+pdk bundle exec bolt command run 'puppet module list' --targets localhost:2222 -i spec/fixtures/litmus_inventory.yaml
+```
+
+The output should look similar to:
+
+```
+Started on localhost...
+Finished on localhost:
+  STDOUT:
+    /etc/puppetlabs/code/environments/production/modules
+    ├── puppetlabs-motd (v2.1.2)
+    ├── puppetlabs-registry (v2.1.0)
+    ├── puppetlabs-stdlib (v5.2.0)
+    └── puppetlabs-translate (v1.2.0)
+    /etc/puppetlabs/code/modules (no modules installed)
+    /opt/puppetlabs/puppet/modules (no modules installed)
+Successful on 1 node: localhost:2222
+Ran on 1 node in 1.11 seconds
+Started on localhost:2222...
+Finished on localhost:2222:
+  STDOUT:
+    /etc/puppetlabs/code/environments/production/modules
+    ├── puppetlabs-motd (v4.1.0)
+    ├── puppetlabs-registry (v3.1.0)
+    ├── puppetlabs-stdlib (v6.2.0)
+    └── puppetlabs-translate (v2.1.0)
+    /etc/puppetlabs/code/modules (no modules installed)
+    /opt/puppetlabs/puppet/modules (no modules installed)
+Successful on 1 target: localhost:2222
+Ran on 1 target in 1.77 sec
+```
+
+Note that you have also installed the MoTD module's dependent modules.
+
+## 6. Run the MoTD acceptance tests
+
+To run acceptance tests with Litmus, run the following command from your working directory:
+
+```
+pdk bundle exec rake litmus:acceptance:parallel
+```
+
+This command executes the acceptance tests in the [acceptance folder](https://github.com/puppetlabs/puppetlabs-motd/tree/main/spec/acceptance) of the module. If the tests have run successfully, you will see output similar to (Note it will look like it has stalled but is actually running tests in the background, please be patient and the output will appear when the tests are complete:
+
+```
++ [✔] Running against 1 targets.
+|__ [✔] localhost:2222, centos:7
+================
+localhost:2222, centos:7
+......
+
+Finished in 42.95 seconds (files took 10.15 seconds to load)
+6 examples, 0 failures
+
+pid 1476 exit 0
+Successful on 1 nodes: ["localhost:2222, centos:7"]
+```
+
+## 7. Remove the Docker image.
+
+Now that you have completed your tests, you can remove the Docker image with the Litmus tear down command:
+
+```
+pdk bundle exec rake litmus:tear_down
+```
+
+You should see JSON output, similar to:
+
+```
+localhost:2222: success
+```
+
+To verify that the target has been removed, run `docker ps` from the command line. You should see that it's no longer running.
+
+## Next steps
+
+The MoTD shows you how to use Litmus to acceptance test an existing module. As you scale up your acceptance testing, you will need to write your own acceptance tests. Try out the following:
+
+* Provision more than one system, for example, `pdk bundle exec rake 'litmus:provision[docker, centos:6]'`. Note that you will need to re-run the `install_agent` and `install_module` command if you want to run tests.
+* Look at the inventory file and take note of the ssh connection information
+* ssh into the CentOS box when you know the password, for example, `ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@localhost -p 2222`, or use Bolt as shown in the example.
+* ssh into the CentOS box without a password, run `docker ps`, take note of the Container Name and then run `docker exec -it litmusimage_centos_7-2222 '/bin/bash'` in this example litmusimage_centos_7-2222 is the Container Name. 
+
+> Note: We have moved all our PR testing to public pipelines to make contributing to Puppet supported modules a better experience. Check out our [PR testing matrix](https://github.com/puppetlabs/puppetlabs-apache/pull/2141) Github Actions. All of our testing is now ran in the one place.

--- a/docs/md/content/usage/tools-included-in-Litmus.md
+++ b/docs/md/content/usage/tools-included-in-Litmus.md
@@ -1,0 +1,43 @@
+---
+layout: page
+title: Tools
+description: Learn the tools Litmus uses.
+---
+
+Litmus wraps functionality from other tools, providing a rake interface for you to develop modules.
+
+* [Bolt](https://github.com/puppetlabs/bolt) is an open source orchestration tool that automates the manual work it takes to maintain your infrastructure. Litmus is built on top of bolt, so it natively handles SSH, WinRM and Docker. The inventory file specifies the protocol to use for each target, when using litmus this can be found in `spec/fixtures/litmus_inventory.yaml`, along with connection specific information. Litmus uses Bolt to execute module tasks.
+* [Serverspec](https://serverspec.org/) lets you check your servers are configured correctly.
+* Puppet Development Kit (PDK) provides a complete module structure, templates for classes, defined types, and tasks, and a testing infrastructure.
+* [Litmus Image](https://github.com/puppetlabs/litmus_image) is a group of Docker build files. They are specifically designed to set up systemd/upstart on various nix images. This is a prerequisite for testing services with Puppet in Docker images.`litmus_image` generates an inventory file, that contains connection information for each system instance. This is used by subsequent commands or by rspec.
+
+These tools are built into the Litmus commands:
+
+#### Provision
+
+To provision systems we created a [module](https://github.com/puppetlabs/provision) that will provision containers / images / hardware in ABS (internal to Puppet) and Docker instances. Provision is extensible, so other provisioners can be added - please raise an [issue](https://github.com/puppetlabs/provision/issues) on the Provision repository, or create your own and submit a [PR](https://github.com/puppetlabs/provision/pulls)!
+
+rake task -> litmus -> bolt -> provision -> docker
+                                         -> vagrant
+                                         -> abs (internal)
+                                         -> vmpooler (internal)
+
+#### Installing an agents
+
+rake task -> bolt -> puppet_agent module
+
+#### Installing modules
+
+PDK builds the module tar file and is copied to the target using Bolt. On the target machine, run `puppet module install`, specifying the tar file. This installs the dependencies listed in the metadata.json of the built module.
+
+rake task -> pdk -> bolt
+
+#### Running tests
+
+rake task -> serverspec -> rspec
+
+#### Tearing down targets
+
+rake task -> bolt provision -> docker
+                            -> abs (internal)
+                            -> vmpooler

--- a/docs/md/go.mod
+++ b/docs/md/go.mod
@@ -1,0 +1,3 @@
+module github.com/puppetlabs/puppet_litmus/docs/md
+
+go 1.17

--- a/docs/md/md.go
+++ b/docs/md/md.go
@@ -1,0 +1,10 @@
+package md
+
+import "embed"
+
+//go:embed content/***
+var DocsFS embed.FS
+
+func GetDocsFS() embed.FS {
+	return DocsFS
+}


### PR DESCRIPTION
This PR aims to migrate the litmus documentation from https://github.com/puppetlabs/litmus to the CAT team site.

This PR includes:

- Introduction of markdown files containing litmus documentation
- Addition of folders to store the markdown files.
- Introduction of go module for hugo/doc integration