### PR TITLE
(MAINT) Address rubocop errors

### DIFF
--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -231,11 +231,11 @@ module PuppetLitmus::RakeHelper
   def configure_path(inventory_hash)
     results = []
     # fix the path on ssh_nodes
-    unless inventory_hash['groups'].select { |group| group['name'] == 'ssh_nodes' && !group['targets'].empty? }.size.zero?
+    unless inventory_hash['groups'].select { |group| group['name'] == 'ssh_nodes' && !group['targets'].empty? }.empty?
       results << run_command('echo PATH="$PATH:/opt/puppetlabs/puppet/bin" > /etc/environment',
                              'ssh_nodes', config: nil, inventory: inventory_hash)
     end
-    unless inventory_hash['groups'].select { |group| group['name'] == 'winrm_nodes' && !group['targets'].empty? }.size.zero?
+    unless inventory_hash['groups'].select { |group| group['name'] == 'winrm_nodes' && !group['targets'].empty? }.empty?
       results << run_command('[Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\Program Files\Puppet Labs\Puppet\bin;C:\Program Files (x86)\Puppet Labs\Puppet\bin", "Machine")',
                              'winrm_nodes', config: nil, inventory: inventory_hash)
     end
@@ -377,7 +377,7 @@ module PuppetLitmus::RakeHelper
       end
       span.add_field('litmus.connectivity_success', results.select { |r| r['status'] == 'success' })
       span.add_field('litmus.connectivity_failure', results.reject { |r| r['status'] == 'success' })
-      raise "Connectivity has failed on: #{failed}" unless failed.length.zero?
+      raise "Connectivity has failed on: #{failed}" unless failed.empty?
 
       puts 'Connectivity check PASSED.'
       true

--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -328,7 +328,7 @@ namespace :litmus do
     end
     puts ''
     # output the things that went wrong, after the successes
-    puts 'something went wrong:' unless bad_results.size.zero?
+    puts 'something went wrong:' unless bad_results.empty??
     bad_results.each do |result|
       puts result
     end


### PR DESCRIPTION
Prior to this commit failures are present on the CI testing due to rubocop failures. 

This commit addresses the failures.