### PR TITLE
(maint) - Update windows 2019 image

### DIFF
--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -11,9 +11,8 @@ IMAGE_TABLE = {
   'RedHat-9' => 'rhel-9',
   'SLES-12' => 'sles-12',
   'SLES-15' => 'sles-15',
-  # 'Windows-2012 R2' => 'windows-2012-r2-core',
   'Windows-2016' => 'windows-2016',
-  'Windows-2019' => 'windows-2019-core',
+  'Windows-2019' => 'windows-2019',
   'Windows-2022' => 'windows-2022',
 }.freeze
 


### PR DESCRIPTION
Prior to this PR, litmus would provision a windows-2019-core image when performing testing against windows 2019 machines. This caused failures on and blocks part of the essential testing on the sqlserver module, with this error 
"The following error occurred:
       You have selected a feature that is not supported on Windows Server Core."

The same tests pass on the other non-core windows machines.

This PR aims to update the windows-2019 image used, to a different windows 2019 image in GCP. ([here](https://console.cloud.google.com/compute/imagesDetail/projects/gce-uefi-images/global/images/windows-server-2019-dc-v20200609?orgonly=true&project=ia-content&supportedpurview=project))