### PR TITLE
(CONT-712) Pin r10k gem

### DIFF
--- a/puppet_litmus.gemspec
+++ b/puppet_litmus.gemspec
@@ -33,4 +33,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rspec'
   spec.add_runtime_dependency 'honeycomb-beeline'
   spec.add_runtime_dependency 'rspec_honeycomb_formatter'
+
+  # Set a hard dependency on r10k 3.15.1 to avoid a dependency issues with gettext-setup
+  # and earlier versions of puppet
+  spec.add_runtime_dependency 'r10k', '= 3.15.1'
 end


### PR DESCRIPTION
This PR pins the r10k gem to 3.15.1 so that we do not hit dependency issues with gettext-setup and earlier versions of puppet.

This pin can probably be removed once puppet 6 has been fully retired.