### PR TITLE
(CONT-764) Update matrix_from_metadata_v2

### DIFF
--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -41,12 +41,12 @@ DOCKER_PLATFORMS = {
 # comparison when evaluating puppet requirements from the metadata
 COLLECTION_TABLE = [
   {
-    puppet_maj_version: 6,
-    ruby_version: 2.5,
-  },
-  {
     puppet_maj_version: 7,
     ruby_version: 2.7,
+  },
+  {
+    puppet_maj_version: 8,
+    ruby_version: 3.2,
   },
 ].freeze
 

--- a/spec/exe/fake_metadata.json
+++ b/spec/exe/fake_metadata.json
@@ -37,10 +37,10 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
-  "template-ref": "heads/main-0-g2381db6",
-  "pdk-version": "2.1.1"
+  "template-ref": "tags/2.7.4",
+  "pdk-version": "2.7.4"
 }

--- a/spec/exe/matrix_from_metadata_v2_spec.rb
+++ b/spec/exe/matrix_from_metadata_v2_spec.rb
@@ -21,13 +21,13 @@ RSpec.describe 'matrix_from_metadata_v2' do
           '{"label":"Ubuntu-18.04","provider":"provision::docker","image":"litmusimage/ubuntu:18.04"}',
           '],',
           '"collection":[',
-          '"puppet6-nightly","puppet7-nightly"',
+          '"puppet7-nightly","puppet8-nightly"',
           ']',
           '}',
         ].join,
       )
       expect(result.stdout).to include(
-        '::set-output name=spec_matrix::{"include":[{"puppet_version":"~> 6.0","ruby_version":2.5},{"puppet_version":"~> 7.0","ruby_version":2.7}]}',
+        '::set-output name=spec_matrix::{"include":[{"puppet_version":"~> 7.0","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}',
       )
       expect(result.stdout).to include("Created matrix with 8 cells:\n  - Acceptance Test Cells: 6\n  - Spec Test Cells: 2")
     end
@@ -51,13 +51,13 @@ RSpec.describe 'matrix_from_metadata_v2' do
           '{"label":"RedHat-8","provider":"provision::provision_service","image":"rhel-8"}',
           '],',
           '"collection":[',
-          '"puppet6-nightly","puppet7-nightly"',
+          '"puppet7-nightly","puppet8-nightly"',
           ']',
           '}',
         ].join,
       )
       expect(result.stdout).to include(
-        '::set-output name=spec_matrix::{"include":[{"puppet_version":"~> 6.0","ruby_version":2.5},{"puppet_version":"~> 7.0","ruby_version":2.7}]}',
+        '::set-output name=spec_matrix::{"include":[{"puppet_version":"~> 7.0","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}',
       )
       expect(result.stdout).to include("Created matrix with 6 cells:\n  - Acceptance Test Cells: 4\n  - Spec Test Cells: 2")
     end
@@ -81,13 +81,13 @@ RSpec.describe 'matrix_from_metadata_v2' do
           '{"label":"CentOS-6","provider":"provision::docker","image":"litmusimage/centos:6"}',
           '],',
           '"collection":[',
-          '"puppet6-nightly","puppet7-nightly"',
+          '"puppet7-nightly","puppet8-nightly"',
           ']',
           '}',
         ].join,
       )
       expect(result.stdout).to include(
-        '::set-output name=spec_matrix::{"include":[{"puppet_version":"~> 6.0","ruby_version":2.5},{"puppet_version":"~> 7.0","ruby_version":2.7}]}',
+        '::set-output name=spec_matrix::{"include":[{"puppet_version":"~> 7.0","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}',
       )
       expect(result.stdout).to include("Created matrix with 4 cells:\n  - Acceptance Test Cells: 2\n  - Spec Test Cells: 2")
     end


### PR DESCRIPTION
Prior to this change matrix_from_metadata_v2 included puppet 6 and puppet 7 collections.

This change adds support for puppet8 and drops puppet 6.