### PR TITLE
(maint) Return Puppet 6 to matrix_from_metadata_v2

### DIFF
--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -60,6 +60,10 @@ DOCKER_PLATFORMS = {
 # comparison when evaluating puppet requirements from the metadata
 COLLECTION_TABLE = [
   {
+    puppet_maj_version: 6,
+    ruby_version: 2.5,
+  },
+  {
     puppet_maj_version: 7,
     ruby_version: 2.7,
   },


### PR DESCRIPTION
Although we are dropping support for 6 we do not yet want to remove it from the generator as the removal of support will be a process and not an immediate action.