### PR TITLE
(MAINT) Force newer Puppet 7 Gem

### DIFF
--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -142,11 +142,13 @@ if metadata.key?('requirements') && metadata['requirements'].length.positive?
       next unless Gem::Requirement.create(reqs).satisfied_by?(Gem::Version.new("#{collection[:puppet_maj_version]}.9999"))
 
       matrix[:collection] << "puppet#{collection[:puppet_maj_version]}-nightly"
-      spec_matrix[:include] << if collection[:puppet_maj_version] == 8
-                                 { puppet_version: 'https://github.com/puppetlabs/puppet', ruby_version: collection[:ruby_version] }
-                               else
-                                 { puppet_version: "~> #{collection[:puppet_maj_version]}.0", ruby_version: collection[:ruby_version] }
-                               end
+
+      include_version = {
+        8 => "~> #{collection[:puppet_maj_version]}.0",
+        7 => "~> #{collection[:puppet_maj_version]}.24",
+        6 => "~> #{collection[:puppet_maj_version]}.0"
+      }
+      spec_matrix[:include] << { puppet_version: include_version[collection[:puppet_maj_version]], ruby_version: collection[:ruby_version] }
     end
   end
 end

--- a/spec/exe/matrix_from_metadata_v2_spec.rb
+++ b/spec/exe/matrix_from_metadata_v2_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
         ].join
       )
       expect(github_output_content).to include(
-        'spec_matrix={"include":[{"puppet_version":"~> 7.0","ruby_version":2.7},{"puppet_version":"https://github.com/puppetlabs/puppet","ruby_version":3.2}]}'
+        'spec_matrix={"include":[{"puppet_version":"~> 7.24","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
       )
       expect(result.stdout).to include("Created matrix with 8 cells:\n  - Acceptance Test Cells: 6\n  - Spec Test Cells: 2")
     end
@@ -69,7 +69,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
         ].join
       )
       expect(github_output_content).to include(
-        'spec_matrix={"include":[{"puppet_version":"~> 7.0","ruby_version":2.7},{"puppet_version":"https://github.com/puppetlabs/puppet","ruby_version":3.2}]}'
+        'spec_matrix={"include":[{"puppet_version":"~> 7.24","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
       )
       expect(result.stdout).to include("Created matrix with 6 cells:\n  - Acceptance Test Cells: 4\n  - Spec Test Cells: 2")
     end
@@ -105,7 +105,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
         ].join
       )
       expect(github_output_content).to include(
-        'spec_matrix={"include":[{"puppet_version":"~> 7.0","ruby_version":2.7},{"puppet_version":"https://github.com/puppetlabs/puppet","ruby_version":3.2}]}'
+        'spec_matrix={"include":[{"puppet_version":"~> 7.24","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
       )
       expect(result.stdout).to include("Created matrix with 4 cells:\n  - Acceptance Test Cells: 2\n  - Spec Test Cells: 2")
     end


### PR DESCRIPTION
After the realease of Puppet 8 there seems to be some confusion with bundler causing it to pull older versions of Puppet 7.

This breaks CI.

This change forces puppet_maj_version == 7 to pull ~> 7.24.