### PR TITLE
feat: install an offline module using the tar.gz

### DIFF
--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -201,7 +201,7 @@ namespace :litmus do
     # module_tar = Dir.glob('pkg/*.tar.gz').max_by { |f| File.mtime(f) }
     raise "Unable to find package in 'pkg/*.tar.gz'" if module_tar.nil?
 
-    install_module(inventory_hash, args[:target_node_name], module_tar, args[:module_repository])
+    install_module(inventory_hash, args[:target_node_name], module_tar, args[:module_repository], true)
 
     puts "Installed '#{module_tar}' on #{args[:target_node_name]}"
   end


### PR DESCRIPTION
## Summary

This pull request allows the test of a module that have not been released to the forge yet or simply needs to remain private. Please see #503 

## How

The module is built , then uploaded and the installation is done without its dependencies.
dependencies are then parsed using the metadata.json file and installed automatically

## Additional Context
Add any additional context about the problem here. 
- [ ] The puppet agent tries to contact the forge to install the unreleased package. 

## Related Issues (if any)
#503 

## Checklist
- [ ] 🟢 Tested by hand. Modules is installed and dependencies as well. 