### PR TITLE
(FEAT) - Add ability to supply a custom matrix and override default provisioner

### DIFF
--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -94,6 +94,29 @@ else
   exclude_list = []
 end
 
+# Force the use of the provision_service provisioner, if the --provision-service argument is present
+if ARGV.include?('--provision-service')
+  provision_service_occurrences = ARGV.count { |arg| arg == '--provision-service' }
+  raise 'the --provision-service argument should be present just one time in the command' unless provision_service_occurrences <= 1
+
+  # NOTE: that the below are the only available images for the provision service
+  updated_platforms = {
+    'CentOS-7' => 'centos-7',
+    'CentOS-8' => 'centos-stream-8',
+    'Rocky-8' => 'rocky-linux-8',
+    'Debian-10' => 'debian-10',
+    'Debian-11' => 'debian-11',
+    'Ubuntu-20.04' => 'ubuntu-2004-lts',
+    'Ubuntu-22.04' => 'ubuntu-2204-lts'
+  }
+
+  updated_list = IMAGE_TABLE.dup.clone
+  updated_list.merge!(updated_platforms)
+
+  IMAGE_TABLE = updated_list.freeze
+  DOCKER_PLATFORMS = {}.freeze
+end
+
 metadata_path = ENV['TEST_MATRIX_FROM_METADATA'] || 'metadata.json'
 metadata = JSON.parse(File.read(metadata_path))
 # Set platforms based on declared operating system support
@@ -105,13 +128,13 @@ metadata['operatingsystem_support'].sort_by { |a| a['operatingsystem'] }.each do
     if IMAGE_TABLE.key?(image_key) && !exclude_list.include?(image_key.downcase)
       matrix[:platforms] << {
         label: image_key,
-        provider: 'provision::provision_service',
+        provider: 'provision_service',
         image: IMAGE_TABLE[image_key]
       }
     elsif DOCKER_PLATFORMS.key?(image_key) && !exclude_list.include?(image_key.downcase)
       matrix[:platforms] << {
         label: image_key,
-        provider: 'provision::docker',
+        provider: 'docker',
         image: DOCKER_PLATFORMS[image_key]
       }
     else

--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -127,7 +127,7 @@ if ARGV.include?('--custom-matrix')
   raise '--custom-matrix argument should be present just one time in the command' unless custom_matrix_occurrences <= 1
 
   file_path = ARGV[ARGV.find_index('--custom-matrix') + 1]
-  raise 'you need to specify a file path' if file_path.nil?
+  raise 'no file path specified' if file_path.nil?
 
   begin
     custom_matrix = JSON.parse(File.read(file_path))

--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -119,27 +119,52 @@ end
 
 metadata_path = ENV['TEST_MATRIX_FROM_METADATA'] || 'metadata.json'
 metadata = JSON.parse(File.read(metadata_path))
-# Set platforms based on declared operating system support
-metadata['operatingsystem_support'].sort_by { |a| a['operatingsystem'] }.each do |sup|
-  os = sup['operatingsystem']
-  sup['operatingsystemrelease'].sort_by(&:to_i).each do |ver|
-    image_key = "#{os}-#{ver}"
 
-    if IMAGE_TABLE.key?(image_key) && !exclude_list.include?(image_key.downcase)
-      matrix[:platforms] << {
-        label: image_key,
-        provider: 'provision_service',
-        image: IMAGE_TABLE[image_key]
-      }
-    elsif DOCKER_PLATFORMS.key?(image_key) && !exclude_list.include?(image_key.downcase)
-      matrix[:platforms] << {
-        label: image_key,
-        provider: 'docker',
-        image: DOCKER_PLATFORMS[image_key]
-      }
+if ARGV.include?('--custom-matrix')
+  custom_matrix_occurrences = ARGV.count { |arg| arg == '--custom-matrix' }
+  raise '--custom-matrix argument should be present just one time in the command' unless custom_matrix_occurrences <= 1
+
+  file_path = ARGV[ARGV.find_index('--custom-matrix') + 1]
+  raise 'you need to specify a file path' if file_path.nil?
+
+  begin
+    custom_matrix = JSON.parse(File.read(file_path))
+  rescue StandardError => e
+    case e
+    when JSON::ParserError
+      raise 'the matrix must be an array of valid JSON objects'
+    when Errno::ENOENT
+      raise "File not found: #{e.message}"
     else
-      puts "::warning::#{image_key} was excluded from testing" if exclude_list.include?(image_key.downcase)
-      puts "::warning::Cannot find image for #{image_key}" unless exclude_list.include?(image_key.downcase)
+      raise "An unknown exception occurred: #{e.message}"
+    end
+  end
+  custom_matrix.each do |platform|
+    matrix[:platforms] << platform
+  end
+else
+  # Set platforms based on declared operating system support
+  metadata['operatingsystem_support'].sort_by { |a| a['operatingsystem'] }.each do |sup|
+    os = sup['operatingsystem']
+    sup['operatingsystemrelease'].sort_by(&:to_i).each do |ver|
+      image_key = "#{os}-#{ver}"
+
+      if IMAGE_TABLE.key?(image_key) && !exclude_list.include?(image_key.downcase)
+        matrix[:platforms] << {
+          label: image_key,
+          provider: 'provision_service',
+          image: IMAGE_TABLE[image_key]
+        }
+      elsif DOCKER_PLATFORMS.key?(image_key) && !exclude_list.include?(image_key.downcase)
+        matrix[:platforms] << {
+          label: image_key,
+          provider: 'docker',
+          image: DOCKER_PLATFORMS[image_key]
+        }
+      else
+        puts "::warning::#{image_key} was excluded from testing" if exclude_list.include?(image_key.downcase)
+        puts "::warning::Cannot find image for #{image_key}" unless exclude_list.include?(image_key.downcase)
+      end
     end
   end
 end

--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -205,9 +205,8 @@ end
 
 # Set to defaults (all collections) if no matches are found
 matrix[:collection] = COLLECTION_TABLE.map { |collection| "puppet#{collection[:puppet_maj_version]}-nightly" } if matrix[:collection].empty?
-
 # Just to make sure there aren't any duplicates
-matrix[:platforms] = matrix[:platforms].uniq.sort_by { |a| a[:label] }
+matrix[:platforms] = matrix[:platforms].uniq.sort_by { |a| a[:label] } unless ARGV.include?('--custom-matrix')
 matrix[:collection] = matrix[:collection].uniq.sort
 
 set_output('matrix', JSON.generate(matrix))

--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -101,9 +101,10 @@ if ARGV.include?('--provision-service')
 
   # NOTE: that the below are the only available images for the provision service
   updated_platforms = {
+    'AlmaLinux-8' => 'almalinux-cloud/almalinux-8',
     'CentOS-7' => 'centos-7',
     'CentOS-8' => 'centos-stream-8',
-    'Rocky-8' => 'rocky-linux-8',
+    'Rocky-8' => 'rocky-linux-cloud/rocky-linux-8',
     'Debian-10' => 'debian-10',
     'Debian-11' => 'debian-11',
     'Ubuntu-20.04' => 'ubuntu-2004-lts',
@@ -120,6 +121,7 @@ end
 metadata_path = ENV['TEST_MATRIX_FROM_METADATA'] || 'metadata.json'
 metadata = JSON.parse(File.read(metadata_path))
 
+# Allow the user to pass a file containing a custom matrix
 if ARGV.include?('--custom-matrix')
   custom_matrix_occurrences = ARGV.count { |arg| arg == '--custom-matrix' }
   raise '--custom-matrix argument should be present just one time in the command' unless custom_matrix_occurrences <= 1

--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -287,7 +287,7 @@ module PuppetLitmus::RakeHelper
     if SUPPORTED_PROVISIONERS.include?(provisioner)
       "provision::#{provisioner}"
     else
-      warn "WARNING: Unsuported provisioner '#{provisioner}', try #{SUPPORTED_PROVISIONERS.join('/')}"
+      warn "WARNING: Unsupported provisioner '#{provisioner}', try #{SUPPORTED_PROVISIONERS.join('/')}"
       provisioner.to_s
     end
   end

--- a/spec/exe/matrix_from_metadata_v2_spec.rb
+++ b/spec/exe/matrix_from_metadata_v2_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe 'matrix_from_metadata_v2' do
         [
           'matrix={',
           '"platforms":[',
-          '{"label":"CentOS-6","provider":"provision::docker","image":"litmusimage/centos:6"},',
-          '{"label":"RedHat-8","provider":"provision::provision_service","image":"rhel-8"},',
-          '{"label":"Ubuntu-18.04","provider":"provision::docker","image":"litmusimage/ubuntu:18.04"}',
+          '{"label":"CentOS-6","provider":"docker","image":"litmusimage/centos:6"},',
+          '{"label":"RedHat-8","provider":"provision_service","image":"rhel-8"},',
+          '{"label":"Ubuntu-18.04","provider":"docker","image":"litmusimage/ubuntu:18.04"}',
           '],',
           '"collection":[',
           '"puppet7-nightly","puppet8-nightly"',
@@ -59,8 +59,8 @@ RSpec.describe 'matrix_from_metadata_v2' do
         [
           'matrix={',
           '"platforms":[',
-          '{"label":"CentOS-6","provider":"provision::docker","image":"litmusimage/centos:6"},',
-          '{"label":"RedHat-8","provider":"provision::provision_service","image":"rhel-8"}',
+          '{"label":"CentOS-6","provider":"docker","image":"litmusimage/centos:6"},',
+          '{"label":"RedHat-8","provider":"provision_service","image":"rhel-8"}',
           '],',
           '"collection":[',
           '"puppet7-nightly","puppet8-nightly"',
@@ -96,7 +96,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
         [
           'matrix={',
           '"platforms":[',
-          '{"label":"CentOS-6","provider":"provision::docker","image":"litmusimage/centos:6"}',
+          '{"label":"CentOS-6","provider":"docker","image":"litmusimage/centos:6"}',
           '],',
           '"collection":[',
           '"puppet7-nightly","puppet8-nightly"',


### PR DESCRIPTION
## Summary
This PR adds the ability to override the default provider for the litmus images from docker to the provision_service, by supplying the `--provision-service` flag.
It also adds  the ability to supply a custom matrix (supplied as a file path), so the user can define their images, providers and labels used by matrix_from_metadata_v2. This can be done by passing the `--custom-matrix /path/to/matrix.json` argument.

## Additional Context
This PR also removes the unnecessary `provision::` prefix from the provisioner, to prevent this error being continuously thrown:
`Unsupported provisioner 'provision::docker', try abs/docker/docker_exp/provision_service/vagrant/vmpooler`

## Related Issues (if any)
Closes https://github.com/puppetlabs/puppet_litmus/issues/453

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
