### PR TITLE
(CONT-1243) - Skip tear_down if no provisioner found

### DIFF
--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -98,7 +98,8 @@ module PuppetLitmus::RakeHelper
 
     results = {}
     targets.each do |node_name|
-      next if node_name == 'litmus_localhost'
+      #  next if local host or provisioner fact empty/not set (GH-421)
+      next if node_name == 'litmus_localhost' || facts_from_node(inventory_hash, node_name)['provisioner'].nil?
 
       result = tear_down(node_name, inventory_hash)
       # Some provisioners tear_down targets that were created as a batch job.


### PR DESCRIPTION
## Summary
If no provisioner fact is present, skip tearing down and move on to next node.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Fixes https://github.com/puppetlabs/puppet_litmus/issues/421

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
