### PR TITLE
(CAT-1249) - Fix Spinner on Windows Hosts

### DIFF
--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -328,7 +328,7 @@ module PuppetLitmus::RakeHelper
   end
 
   def start_spinner(message)
-    if (ENV['CI'] || '').casecmp('true').zero?
+    if (ENV['CI'] || '').casecmp('true').zero? || Gem.win_platform?
       puts message
       spinner = Thread.new do
         # CI systems are strange beasts, we only output a '.' every wee while to keep the terminal alive.
@@ -346,7 +346,7 @@ module PuppetLitmus::RakeHelper
   end
 
   def stop_spinner(spinner)
-    if (ENV['CI'] || '').casecmp('true').zero?
+    if (ENV['CI'] || '').casecmp('true').zero? || Gem.win_platform?
       Thread.kill(spinner)
     else
       spinner.success


### PR DESCRIPTION
This PR fixes an incompatibility issue with windows hosts and tty spinner.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Fixes https://github.com/puppetlabs/puppet_litmus/issues/144

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
