### PR TITLE
(CAT-1241) - Adding retry when provision failed with Timeout

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,7 +23,7 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns, inherit_mode.
 # AllowedMethods: refine
 Metrics/BlockLength:
-  Max: 345
+  Max: 350
 
 # Offense count: 8
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -99,7 +99,7 @@ namespace :litmus do
     rescue PuppetLitmus::RakeHelper::LitmusTimeoutError
       current_retry_count += 1
       Rake::Task['litmus:tear_down'].invoke(target_names.first)
-      raise if current_retry_count >= retry_count
+      raise if current_retry_count > retry_count
 
       puts "Provision of node #{target_names.first} failed, Retrying #{current_retry_count} of #{retry_count}"
       retry


### PR DESCRIPTION
## Summary
We have seen many times the PR CI is gets failed due to Connectivity check Timeout which lead to failure for the workflow, but the same can be successful if we retries.
So adding 3 retries whenever there is timeout failure.

## Additional Context
- N/A

## Related Issues (if any)
- N/A

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
