### PR TITLE
(CAT-1521) - Adding new OS RHEL-9 ARM

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -80,7 +80,7 @@ RSpec/DescribeClass:
 # Offense count: 31
 # Configuration parameters: CountAsOne.
 RSpec/ExampleLength:
-  Max: 19
+  Max: 20
 
 # Offense count: 126
 # Configuration parameters: .

--- a/exe/matrix_from_metadata
+++ b/exe/matrix_from_metadata
@@ -27,6 +27,8 @@ end
 IMAGE_TABLE = {
   'RedHat-7' => 'rhel-7',
   'RedHat-8' => 'rhel-8',
+  'RedHat-9' => 'rhel-9',
+  'RedHat-9-arm' => 'rhel-9-arm64',
   'SLES-12' => 'sles-12',
   'SLES-15' => 'sles-15',
   'Windows-2012 R2' => 'windows-2012-r2-core',

--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -28,6 +28,7 @@ IMAGE_TABLE = {
   'RedHat-7' => 'rhel-7',
   'RedHat-8' => 'rhel-8',
   'RedHat-9' => 'rhel-9',
+  'RedHat-9-arm' => 'rhel-9-arm64',
   'SLES-12' => 'sles-12',
   'SLES-15' => 'sles-15',
   'Windows-2016' => 'windows-2016',

--- a/spec/exe/fake_metadata.json
+++ b/spec/exe/fake_metadata.json
@@ -23,7 +23,8 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9-arm"
       ]
     },
     {

--- a/spec/exe/matrix_from_metadata_v2_spec.rb
+++ b/spec/exe/matrix_from_metadata_v2_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
           '"platforms":[',
           '{"label":"CentOS-6","provider":"docker","image":"litmusimage/centos:6"},',
           '{"label":"RedHat-8","provider":"provision_service","image":"rhel-8"},',
+          '{"label":"RedHat-9-arm","provider":"provision_service","image":"rhel-9-arm64"},',
           '{"label":"Ubuntu-18.04","provider":"docker","image":"litmusimage/ubuntu:18.04"}',
           '],',
           '"collection":[',
@@ -35,7 +36,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 7.24","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
       )
-      expect(result.stdout).to include("Created matrix with 8 cells:\n  - Acceptance Test Cells: 6\n  - Spec Test Cells: 2")
+      expect(result.stdout).to include("Created matrix with 10 cells:\n  - Acceptance Test Cells: 8\n  - Spec Test Cells: 2")
     end
   end
 
@@ -60,7 +61,8 @@ RSpec.describe 'matrix_from_metadata_v2' do
           'matrix={',
           '"platforms":[',
           '{"label":"CentOS-6","provider":"docker","image":"litmusimage/centos:6"},',
-          '{"label":"RedHat-8","provider":"provision_service","image":"rhel-8"}',
+          '{"label":"RedHat-8","provider":"provision_service","image":"rhel-8"},',
+          '{"label":"RedHat-9-arm","provider":"provision_service","image":"rhel-9-arm64"}',
           '],',
           '"collection":[',
           '"puppet7-nightly","puppet8-nightly"',
@@ -71,14 +73,14 @@ RSpec.describe 'matrix_from_metadata_v2' do
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 7.24","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
       )
-      expect(result.stdout).to include("Created matrix with 6 cells:\n  - Acceptance Test Cells: 4\n  - Spec Test Cells: 2")
+      expect(result.stdout).to include("Created matrix with 8 cells:\n  - Acceptance Test Cells: 6\n  - Spec Test Cells: 2")
     end
   end
 
   context 'with --exclude-platforms \'["ubuntu-18.04","redhat-8"]\'' do
     let(:github_output) { Tempfile.new('github_output') }
     let(:github_output_content) { github_output.read }
-    let(:result) { run_matrix_from_metadata_v2({ '--exclude-platforms' => ['ubuntu-18.04', 'redhat-8'] }) }
+    let(:result) { run_matrix_from_metadata_v2({ '--exclude-platforms' => ['ubuntu-18.04', 'redhat-8', 'redhat-9'] }) }
 
     before do
       ENV['GITHUB_OUTPUT'] = github_output.path
@@ -96,7 +98,8 @@ RSpec.describe 'matrix_from_metadata_v2' do
         [
           'matrix={',
           '"platforms":[',
-          '{"label":"CentOS-6","provider":"docker","image":"litmusimage/centos:6"}',
+          '{"label":"CentOS-6","provider":"docker","image":"litmusimage/centos:6"},',
+          '{"label":"RedHat-9-arm","provider":"provision_service","image":"rhel-9-arm64"}',
           '],',
           '"collection":[',
           '"puppet7-nightly","puppet8-nightly"',
@@ -107,7 +110,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 7.24","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
       )
-      expect(result.stdout).to include("Created matrix with 4 cells:\n  - Acceptance Test Cells: 2\n  - Spec Test Cells: 2")
+      expect(result.stdout).to include("Created matrix with 6 cells:\n  - Acceptance Test Cells: 4\n  - Spec Test Cells: 2")
     end
   end
 end


### PR DESCRIPTION
## Summary
Agent Team have certified puppet agent with FOSS RHEL-9-ARM so we need to add for module testing as well.

## Additional Context
- [x] Adding RHEL-9-ARM in litmus

## Related Issues (if any)
N/A

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
