### PR TITLE
(CAT-1545) - Return RHEL-9 ARM images in matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,5 +8,14 @@ on:
 
 jobs:
   spec:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version:
+          - '2.7'
+          - '3.2'
+    name: "spec (ruby ${{ matrix.ruby_version }})"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
     secrets: "inherit"
+    with:
+      ruby_version: ${{ matrix.ruby_version }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,5 +7,14 @@ on:
 
 jobs:
   spec:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version:
+          - '2.7'
+          - '3.2'
+    name: "spec (ruby ${{ matrix.ruby_version }})"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
     secrets: "inherit"
+    with:
+      ruby_version: ${{ matrix.ruby_version }}

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ In order to use this new functionality, run:
 
 `$: bundle exec matrix_from_metadata_v2 --custom-matrix matrix.json`
 
-> Note: The file should contain a valid Array of JSON Objects (i.e. `[{"label":"AlmaLinux-8","provider":"provision_service","image":"almalinux-cloud/almalinux-8","machine_type":"n1-standard-2"}, {"label":"RedHat-9-arm","provider":"provision_service","image":"rhel-9-arm64","machine_type":"t2a-standard-2"}, {..}]`), otherwise it will throw an error.
+> Note: The file should contain a valid Array of JSON Objects (i.e. see [here](https://github.com/puppetlabs/puppet_litmus/blob/main/docs/custom_matrix.json)), otherwise it will throw an error.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ In order to use this new functionality, run:
 
 `$: bundle exec matrix_from_metadata_v2 --custom-matrix matrix.json`
 
-> Note: The file should contain a valid Array of JSON Objects (i.e. `[{"label":"AlmaLinux-8","provider":"provision_service","image":"almalinux-cloud/almalinux-8"}, {..}]`), otherwise it will throw an error.
+> Note: The file should contain a valid Array of JSON Objects (i.e. `[{"label":"AlmaLinux-8","provider":"provision_service","image":"almalinux-cloud/almalinux-8","machine_type":"n1-standard-2"}, {"label":"RedHat-9-arm","provider":"provision_service","image":"rhel-9-arm64","machine_type":"t2a-standard-2"}, {..}]`), otherwise it will throw an error.
 
 ## Documentation
 

--- a/docs/custom_matrix.json
+++ b/docs/custom_matrix.json
@@ -1,0 +1,17 @@
+[
+    {
+        "label":"AlmaLinux-8",
+        "provider":"provision_service",
+        "image":"almalinux-cloud/almalinux-8"
+    },
+    {
+        "label":"RedHat-9",
+        "provider":"provision_service",
+        "image":"rhel-9"
+    },
+    {
+        "label":"centos-7",
+        "provider":"docker",
+        "image":"litmusimage/centos-7"
+    }
+]

--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -28,12 +28,15 @@ IMAGE_TABLE = {
   'RedHat-7' => 'rhel-7',
   'RedHat-8' => 'rhel-8',
   'RedHat-9' => 'rhel-9',
-  'RedHat-9-arm' => 'rhel-9-arm64',
   'SLES-12' => 'sles-12',
   'SLES-15' => 'sles-15',
   'Windows-2016' => 'windows-2016',
   'Windows-2019' => 'windows-2019',
   'Windows-2022' => 'windows-2022'
+}.freeze
+
+ARM_IMAGE_TABLE = {
+  'RedHat-9-arm' => 'rhel-9-arm64'
 }.freeze
 
 DOCKER_PLATFORMS = {
@@ -112,7 +115,6 @@ if ARGV.include?('--provision-service')
     'Ubuntu-20.04' => 'ubuntu-2004-lts',
     'Ubuntu-22.04' => 'ubuntu-2204-lts'
   }
-
   updated_list = IMAGE_TABLE.dup.clone
   updated_list.merge!(updated_platforms)
 
@@ -152,7 +154,14 @@ else
     os = sup['operatingsystem']
     sup['operatingsystemrelease'].sort_by(&:to_i).each do |ver|
       image_key = "#{os}-#{ver}"
-
+      # Add ARM images if they exist and are not excluded
+      if ARM_IMAGE_TABLE.key?("#{image_key}-arm") && !exclude_list.include?("#{image_key.downcase}-arm")
+        matrix[:platforms] << {
+          label: "#{image_key}-arm",
+          provider: 'provision_service',
+          image: ARM_IMAGE_TABLE["#{image_key}-arm"]
+        }
+      end
       if IMAGE_TABLE.key?(image_key) && !exclude_list.include?(image_key.downcase)
         matrix[:platforms] << {
           label: image_key,

--- a/spec/exe/fake_metadata.json
+++ b/spec/exe/fake_metadata.json
@@ -24,7 +24,7 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "8",
-        "9-arm"
+        "9"
       ]
     },
     {

--- a/spec/exe/matrix_from_metadata_v2_spec.rb
+++ b/spec/exe/matrix_from_metadata_v2_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
       expect(result.status_code).to eq 0
     end
 
-    it 'generates the matrix' do
+    it 'generates the matrix' do # rubocop:disable RSpec/ExampleLength
       expect(result.stdout).to include('::warning::Cannot find image for Ubuntu-14.04')
       expect(github_output_content).to include(
         [
@@ -24,6 +24,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
           '"platforms":[',
           '{"label":"CentOS-6","provider":"docker","image":"litmusimage/centos:6"},',
           '{"label":"RedHat-8","provider":"provision_service","image":"rhel-8"},',
+          '{"label":"RedHat-9","provider":"provision_service","image":"rhel-9"},',
           '{"label":"RedHat-9-arm","provider":"provision_service","image":"rhel-9-arm64"},',
           '{"label":"Ubuntu-18.04","provider":"docker","image":"litmusimage/ubuntu:18.04"}',
           '],',
@@ -36,7 +37,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 7.24","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
       )
-      expect(result.stdout).to include("Created matrix with 10 cells:\n  - Acceptance Test Cells: 8\n  - Spec Test Cells: 2")
+      expect(result.stdout).to include("Created matrix with 12 cells:\n  - Acceptance Test Cells: 10\n  - Spec Test Cells: 2")
     end
   end
 
@@ -53,7 +54,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
       expect(result.status_code).to eq 0
     end
 
-    it 'generates the matrix without excluded platforms' do
+    it 'generates the matrix without excluded platforms' do # rubocop:disable RSpec/ExampleLength
       expect(result.stdout).to include('::warning::Cannot find image for Ubuntu-14.04')
       expect(result.stdout).to include('::warning::Ubuntu-18.04 was excluded from testing')
       expect(github_output_content).to include(
@@ -62,6 +63,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
           '"platforms":[',
           '{"label":"CentOS-6","provider":"docker","image":"litmusimage/centos:6"},',
           '{"label":"RedHat-8","provider":"provision_service","image":"rhel-8"},',
+          '{"label":"RedHat-9","provider":"provision_service","image":"rhel-9"},',
           '{"label":"RedHat-9-arm","provider":"provision_service","image":"rhel-9-arm64"}',
           '],',
           '"collection":[',
@@ -73,7 +75,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 7.24","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
       )
-      expect(result.stdout).to include("Created matrix with 8 cells:\n  - Acceptance Test Cells: 6\n  - Spec Test Cells: 2")
+      expect(result.stdout).to include("Created matrix with 10 cells:\n  - Acceptance Test Cells: 8\n  - Spec Test Cells: 2")
     end
   end
 


### PR DESCRIPTION
This PR adds a new constant `ARM_IMAGE_TABLE` which contains viable arm architecture images in GCP.  Now whenever rhel-9 is listed as a supported OS in a modules metadata, both the intel and arm GCP image details are returned.
Have opted for bugfix label as fixes regression in https://github.com/puppetlabs/puppet_litmus/pull/530. We cannot specify `arm` explicitly in the metadata.json.

## Related Issues (if any)
https://perforce.atlassian.net/browse/CAT-1545

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.


Verified with metadata.json containing `rhel-9` that both the rhel-9 intel and rhel-9-arm entries are returned:
```
matrix={"platforms":[{"label":"CentOS-6","provider":"docker","image":"litmusimage/centos:6"},{"label":"RedHat-8","provider":"provision_service","image":"rhel-8"},{"label":"RedHat-9","provider":"provision_service","image":"rhel-9"},{"label":"RedHat-9-arm","provider":"provision_service","image":"rhel-9-arm64"},{"label":"Ubuntu-18.04","provider":"docker","image":"litmusimage/ubuntu:18.04"}],"collection":["puppet7-nightly","puppet8-nightly"]}
spec_matrix={"include":[{"puppet_version":"~> 7.24","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}
```
