### PR TITLE
(CAT-1522) - Adding support for Ubuntu 22.04 ARM OS

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -80,7 +80,7 @@ RSpec/DescribeClass:
 # Offense count: 31
 # Configuration parameters: CountAsOne.
 RSpec/ExampleLength:
-  Max: 20
+  Max: 22
 
 # Offense count: 126
 # Configuration parameters: .

--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -36,7 +36,8 @@ IMAGE_TABLE = {
 }.freeze
 
 ARM_IMAGE_TABLE = {
-  'RedHat-9-arm' => 'rhel-9-arm64'
+  'RedHat-9-arm' => 'rhel-9-arm64',
+  'Ubuntu-22.04-arm' => 'ubuntu-2204-lts-arm64'
 }.freeze
 
 DOCKER_PLATFORMS = {

--- a/spec/exe/fake_metadata.json
+++ b/spec/exe/fake_metadata.json
@@ -31,7 +31,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",
-        "18.04"
+        "18.04",
+        "22.04"
       ]
     }
   ],

--- a/spec/exe/matrix_from_metadata_v2_spec.rb
+++ b/spec/exe/matrix_from_metadata_v2_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe 'matrix_from_metadata_v2' do
           '{"label":"RedHat-8","provider":"provision_service","image":"rhel-8"},',
           '{"label":"RedHat-9","provider":"provision_service","image":"rhel-9"},',
           '{"label":"RedHat-9-arm","provider":"provision_service","image":"rhel-9-arm64"},',
-          '{"label":"Ubuntu-18.04","provider":"docker","image":"litmusimage/ubuntu:18.04"}',
+          '{"label":"Ubuntu-18.04","provider":"docker","image":"litmusimage/ubuntu:18.04"},',
+          '{"label":"Ubuntu-22.04","provider":"docker","image":"litmusimage/ubuntu:22.04"},',
+          '{"label":"Ubuntu-22.04-arm","provider":"provision_service","image":"ubuntu-2204-lts-arm64"}',
           '],',
           '"collection":[',
           '"puppet7-nightly","puppet8-nightly"',
@@ -37,7 +39,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 7.24","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
       )
-      expect(result.stdout).to include("Created matrix with 12 cells:\n  - Acceptance Test Cells: 10\n  - Spec Test Cells: 2")
+      expect(result.stdout).to include("Created matrix with 16 cells:\n  - Acceptance Test Cells: 14\n  - Spec Test Cells: 2")
     end
   end
 
@@ -64,7 +66,9 @@ RSpec.describe 'matrix_from_metadata_v2' do
           '{"label":"CentOS-6","provider":"docker","image":"litmusimage/centos:6"},',
           '{"label":"RedHat-8","provider":"provision_service","image":"rhel-8"},',
           '{"label":"RedHat-9","provider":"provision_service","image":"rhel-9"},',
-          '{"label":"RedHat-9-arm","provider":"provision_service","image":"rhel-9-arm64"}',
+          '{"label":"RedHat-9-arm","provider":"provision_service","image":"rhel-9-arm64"},',
+          '{"label":"Ubuntu-22.04","provider":"docker","image":"litmusimage/ubuntu:22.04"},',
+          '{"label":"Ubuntu-22.04-arm","provider":"provision_service","image":"ubuntu-2204-lts-arm64"}',
           '],',
           '"collection":[',
           '"puppet7-nightly","puppet8-nightly"',
@@ -75,14 +79,14 @@ RSpec.describe 'matrix_from_metadata_v2' do
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 7.24","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
       )
-      expect(result.stdout).to include("Created matrix with 10 cells:\n  - Acceptance Test Cells: 8\n  - Spec Test Cells: 2")
+      expect(result.stdout).to include("Created matrix with 14 cells:\n  - Acceptance Test Cells: 12\n  - Spec Test Cells: 2")
     end
   end
 
   context 'with --exclude-platforms \'["ubuntu-18.04","redhat-8"]\'' do
     let(:github_output) { Tempfile.new('github_output') }
     let(:github_output_content) { github_output.read }
-    let(:result) { run_matrix_from_metadata_v2({ '--exclude-platforms' => ['ubuntu-18.04', 'redhat-8', 'redhat-9'] }) }
+    let(:result) { run_matrix_from_metadata_v2({ '--exclude-platforms' => ['ubuntu-18.04', 'ubuntu-22.04', 'redhat-8', 'redhat-9'] }) }
 
     before do
       ENV['GITHUB_OUTPUT'] = github_output.path
@@ -95,13 +99,15 @@ RSpec.describe 'matrix_from_metadata_v2' do
     it 'generates the matrix without excluded platforms' do
       expect(result.stdout).to include('::warning::Cannot find image for Ubuntu-14.04')
       expect(result.stdout).to include('::warning::Ubuntu-18.04 was excluded from testing')
+      expect(result.stdout).to include('::warning::Ubuntu-22.04 was excluded from testing')
       expect(result.stdout).to include('::warning::RedHat-8 was excluded from testing')
       expect(github_output_content).to include(
         [
           'matrix={',
           '"platforms":[',
           '{"label":"CentOS-6","provider":"docker","image":"litmusimage/centos:6"},',
-          '{"label":"RedHat-9-arm","provider":"provision_service","image":"rhel-9-arm64"}',
+          '{"label":"RedHat-9-arm","provider":"provision_service","image":"rhel-9-arm64"},',
+          '{"label":"Ubuntu-22.04-arm","provider":"provision_service","image":"ubuntu-2204-lts-arm64"}',
           '],',
           '"collection":[',
           '"puppet7-nightly","puppet8-nightly"',
@@ -112,7 +118,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 7.24","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
       )
-      expect(result.stdout).to include("Created matrix with 6 cells:\n  - Acceptance Test Cells: 4\n  - Spec Test Cells: 2")
+      expect(result.stdout).to include("Created matrix with 8 cells:\n  - Acceptance Test Cells: 6\n  - Spec Test Cells: 2")
     end
   end
 end


### PR DESCRIPTION
## Summary

Adding support for Ubuntu 22.04 ARM Operating System.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
