### PR TITLE
(CAT-1688) Upgrade Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,7 @@ AllCops:
 # Disabled
 Style/ClassAndModuleChildren:
   Enabled: false
+Layout/LineLength:
+  Max: 200
+Gemspec/RequireMFA:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,14 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: Severity, Include.
-# Include: **/*.gemspec
-Gemspec/RequireMFA:
-  Exclude:
-    - 'puppet_litmus.gemspec'
-
 # Offense count: 17
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
@@ -116,10 +108,3 @@ Style/OpenStructUse:
   Exclude:
     - 'lib/puppet_litmus/puppet_helpers.rb'
     - 'spec/spec_helper.rb'
-
-# Offense count: 135
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns.
-# URISchemes: http, https
-Layout/LineLength:
-  Max: 199

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :test do
   gem 'rspec-collection_matchers', '~> 1.0'
   gem 'rspec-its', '~> 1.0'
 
-  gem 'rubocop', '~> 1.48.1'
+  gem 'rubocop', '~> 1.50.0'
   gem 'rubocop-rspec', '~> 2.19'
   gem 'rubocop-performance', '~> 1.16'
 


### PR DESCRIPTION
Following a recent team decision, we are implementing a Rubocop Upgrade moving the version from 1.48.1 to 1.50.0. This should be the final version until Puppet 7 is unsupported.
