### PR TITLE
pdksync - (CAT-1618) - Remove deprecated/obsolete codecov gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ group :test do
   gem 'rubocop-rspec', '~> 2.19'
   gem 'rubocop-performance', '~> 1.16'
 
-  gem 'codecov'
   gem 'simplecov'
   gem 'simplecov-console'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,10 +12,6 @@ if ENV['COVERAGE'] == 'yes'
       SimpleCov::Formatter::HTMLFormatter,
       SimpleCov::Formatter::Console
     ]
-    if ENV['CI'] == 'true'
-      require 'codecov'
-      SimpleCov.formatters << SimpleCov::Formatter::Codecov
-    end
 
     SimpleCov.start do
       track_files 'lib/**/*.rb'
@@ -27,7 +23,7 @@ if ENV['COVERAGE'] == 'yes'
       add_filter '/.vendor'
     end
   rescue LoadError
-    raise 'Add the simplecov, simplecov-console, and codecov gems to Gemfile to enable this task'
+    raise 'Add the simplecov & simplecov-console gems to Gemfile to enable this task'
   end
 end
 


### PR DESCRIPTION
(CAT-1618) - Remove deprecated/obsolete codecov gem
pdk version: `3.0.0` 
