### PR TITLE
Minor install_module improvements

### DIFF
--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -241,10 +241,8 @@ namespace :litmus do
     include BoltSpec::Run
     module_tars.each do |module_tar|
       puts "Installing '#{module_tar}'"
-      target_nodes.each do |target_node_name|
-        install_module(inventory_hash, target_node_name, module_tar, args[:module_repository], args[:ignore_dependencies])
-        puts "Installed '#{module_tar}' on #{target_node_name}"
-      end
+      install_module(inventory_hash, target_nodes, module_tar, args[:module_repository], args[:ignore_dependencies])
+      puts "Installed '#{module_tar}' on #{target_nodes.join(', ')}"
     end
   end
 

--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -210,9 +210,9 @@ namespace :litmus do
     # module_tar = Dir.glob('pkg/*.tar.gz').max_by { |f| File.mtime(f) }
     raise "Unable to find package in 'pkg/*.tar.gz'" if module_tar.nil?
 
-    install_module(inventory_hash, args[:target_node_name], module_tar, args[:module_repository])
+    install_module(inventory_hash, target_nodes, module_tar, args[:module_repository])
 
-    puts "Installed '#{module_tar}' on #{args[:target_node_name]}"
+    puts "Installed '#{module_tar}' on #{target_nodes.join(', ')}"
   end
 
   # Install the puppet modules from a source directory to nodes. It does not install dependencies.

--- a/spec/lib/puppet_litmus/util_spec.rb
+++ b/spec/lib/puppet_litmus/util_spec.rb
@@ -5,11 +5,12 @@ load File.expand_path('../../../lib/puppet_litmus/util.rb', __dir__)
 
 RSpec.describe PuppetLitmus::Util do
   context 'when using interpolate_powershell' do
+    let(:command) { 'foo' }
+    let(:encoded) { Base64.strict_encode64(command.encode('UTF-16LE')) }
+
     it 'interpolates the command' do
-      expect(described_class.interpolate_powershell('foo')).to match(/powershell\.exe/)
-      expect(described_class.interpolate_powershell('foo')).to match(/NoProfile/)
-      expect(described_class.interpolate_powershell('foo')).to match(/EncodedCommand/)
-      expect(described_class.interpolate_powershell('foo')).not_to match(/foo/)
+      expect(described_class.interpolate_powershell(command)).to eql("powershell.exe -NoProfile -EncodedCommand #{encoded}")
+      expect(described_class.interpolate_powershell(command)).not_to match(/#{command}/)
     end
   end
 end


### PR DESCRIPTION
* fixes no targets listed in `Installed <module> on ` message when install_module on all targets
* improve performance of install_module_from_directory
* fix install module targets by using the find_targets instead of the rake arg
