### PR TITLE
(BUGFIX) Remove CentOS 6 from `matrix_from_metadata`

### DIFF
--- a/exe/matrix_from_metadata
+++ b/exe/matrix_from_metadata
@@ -37,7 +37,6 @@ IMAGE_TABLE = {
 }.freeze
 
 DOCKER_PLATFORMS = [
-  'CentOS-6',
   'CentOS-7',
   'CentOS-8',
   'Debian-10',

--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -41,7 +41,6 @@ ARM_IMAGE_TABLE = {
 }.freeze
 
 DOCKER_PLATFORMS = {
-  'CentOS-6' => 'litmusimage/centos:6',
   'CentOS-7' => 'litmusimage/centos:7',
   'CentOS-8' => 'litmusimage/centos:stream8', # Support officaly moved to Stream8, metadata is being left as is
   'Rocky-8' => 'litmusimage/rockylinux:8',


### PR DESCRIPTION
## Summary
Cleanup of no longer supported OS

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
