### PR TITLE
drop Debian 9 stretch from matrix

### DIFF
--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -45,7 +45,6 @@ DOCKER_PLATFORMS = {
   'CentOS-8' => 'litmusimage/centos:stream8', # Support officaly moved to Stream8, metadata is being left as is
   'Rocky-8' => 'litmusimage/rockylinux:8',
   'AlmaLinux-8' => 'litmusimage/almalinux:8',
-  'Debian-9' => 'litmusimage/debian:9',
   'Debian-10' => 'litmusimage/debian:10',
   'Debian-11' => 'litmusimage/debian:11',
   'Debian-12' => 'litmusimage/debian:12',


### PR DESCRIPTION
EOL, vendor repos do not work, and Puppet hasn't built agents for a long time