### PR TITLE
use dockercli specinfra backend for docker_nodes

### DIFF
--- a/lib/puppet_litmus/spec_helper_acceptance.rb
+++ b/lib/puppet_litmus/spec_helper_acceptance.rb
@@ -26,7 +26,7 @@ module PuppetLitmus
 
       if target_in_group(inventory_hash, ENV.fetch('TARGET_HOST', nil), 'docker_nodes')
         host = ENV.fetch('TARGET_HOST', nil)
-        set :backend, :docker
+        set :backend, :dockercli
         set :docker_container, host
       elsif target_in_group(inventory_hash, ENV.fetch('TARGET_HOST', nil), 'ssh_nodes')
         set :backend, :ssh


### PR DESCRIPTION
This fixes running Serverspec tests against nodes created by the docker_exp provision task. Unlike the docker bolt transport, the Serverspec docker backend uses the docker API. Unfortunately it lacks support for modern docker contexts (notably ssh).

_Only applies to nodes created with the docker_exp provision task_ 