### PR TITLE
automatically filter provision_service from matrix

### DIFF
--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -123,6 +123,12 @@ if ARGV.include?('--provision-service')
   DOCKER_PLATFORMS = {}.freeze
 end
 
+# disable provision service if repository owner is not puppetlabs
+unless ['puppetlabs', nil].include?(ENV.fetch('GITHUB_REPOSITORY_OWNER', nil))
+  IMAGE_TABLE = {}.freeze
+  ARM_IMAGE_TABLE = {}.freeze
+end
+
 metadata_path = ENV['TEST_MATRIX_FROM_METADATA'] || 'metadata.json'
 metadata = JSON.parse(File.read(metadata_path))
 


### PR DESCRIPTION
When testing changes with workflows on a personal fork, acceptance tests always fail because provision_service hosts are always included. This PR automatically filters them if the owner isn't `puppetlabs`, and the GITHUB_REPOSITORY_OWNER variable is set.