### PR TITLE
(CAT-2052) Pass target container URI instead of container SHA ID to add_feature_to_node() method

### DIFF
--- a/lib/puppet_litmus/rake_tasks.rb
+++ b/lib/puppet_litmus/rake_tasks.rb
@@ -128,6 +128,7 @@ namespace :litmus do
     Rake::Task['spec_prep'].invoke
 
     results = install_agent(args[:collection], targets, inventory_hash)
+    target_index = 0
     results.each do |result|
       command_to_run = "bolt task run puppet_agent::install --targets #{result['target']} --inventoryfile spec/fixtures/litmus_inventory.yaml --modulepath #{DEFAULT_CONFIG_DATA['modulepath']}"
       raise "Failed on #{result['target']}\n#{result}\ntry running '#{command_to_run}'" if result['status'] != 'success'
@@ -157,7 +158,8 @@ namespace :litmus do
       end
 
       # add puppet-agent feature to successful nodes
-      inventory_hash = add_feature_to_node(inventory_hash, 'puppet-agent', result['target'])
+      inventory_hash = add_feature_to_node(inventory_hash, 'puppet-agent', targets[target_index])
+      target_index += 1
     end
 
     # update the inventory with the puppet-agent feature set per node


### PR DESCRIPTION
## Summary
There is a bug in the 'install_agent' task.
It is supposed to install the agent on a host (a VM or a docker container) using bolt and then add the 'puppet-agent' feature to the host in the litmus_inventory file.
Bolt returns the SHA ID of the container instead of the localhost URI after it installs the agent. The feature is added through the add_feature_to_node() method.

The last parameter of the method is being sent as result["target"]. This is fine in the case of VMs since its their IPv4 address and the method is expecting just that.

But in case of docker containers it is their SHA container ID and the method expecting the localhost:{port} URI. This results in the feature not being added to the host.

Since bolt is returning the results in the same order it is provided the input 'targets', we can add the feature by indexing the 'targets' array in that order.

## Additional Context
See https://perforce.atlassian.net/browse/CAT-2052?focusedCommentId=2970824

The [puppetlabs-package nightlies ](https://github.com/puppetlabs/puppetlabs-package/actions/runs/11116201965)are failing due to this on all the docker provisioned VMs. 

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
