### PR TITLE
(FEAT) Add PE to matrix_from_metadata_v3

### DIFF
--- a/exe/matrix_from_metadata_v3
+++ b/exe/matrix_from_metadata_v3
@@ -147,6 +147,8 @@ begin
 
     opt.on('--runner NAME', String, "Default Github action runner (default: #{default_options[:runner]})") { |o| options.runner = o }
 
+    opt.on('--pe-include', TrueClass, 'Include Puppet Enterprise LTS') { |o| options.pe_include = o }
+
     opt.on('--puppet-include MAJOR', Integer, 'Select puppet major version') { |o| options.puppet_include << o }
     opt.on('--puppet-exclude MAJOR', Integer, 'Filter puppet major version') { |o| options.puppet_exclude << o }
 
@@ -219,6 +221,27 @@ options[:metadata]['requirements']&.each do |req|
     break
   end
 
+  gem_req = Gem::Requirement.create(puppet_version_reqs)
+
+  # Add PE LTS to the collection matrix
+  if options[:pe_include]
+    require 'puppet_forge'
+
+    PuppetForge.user_agent = 'Puppet/Litmus'
+
+    forge_conn = PuppetForge::Connection.make_connection('https://forge.puppet.com')
+    pe_tracks = forge_conn.get('/private/versions/pe')
+    lts_tracklist = pe_tracks.body.select { |ver| ver[:lts] == true }
+
+    lts_tracklist.each do |track|
+      if gem_req.satisfied_by?(Gem::Version.new(track[:versions][0][:puppet].to_s))
+        matrix[:collection] << "#{track[:latest]}-puppet_enterprise"
+      else
+        Action.debug("PE #{track[:latest]} (puppet v#{track[:versions][0][:puppet]}) outside requirements #{puppet_version_reqs}")
+      end
+    end
+  end
+
   options[:matrix]['collections'].each do |collection|
     next unless options[:puppet_include].each do |major|
       break if major != collection['puppet'].to_i
@@ -235,7 +258,6 @@ options[:metadata]['requirements']&.each do |req|
 
     # Test against the "largest" puppet version in a collection, e.g. `7.9999` to allow puppet requirements with a non-zero lower bound on minor/patch versions.
     # This assumes that such a boundary will always allow the latest actually existing puppet version of a release stream, trading off simplicity vs accuracy here.
-    gem_req = Gem::Requirement.create(puppet_version_reqs)
     next unless gem_req.satisfied_by?(Gem::Version.new("#{collection['puppet'].to_i}.9999"))
 
     matrix[:collection] << "puppet#{collection['puppet'].to_i}-nightly"

--- a/spec/exe/matrix_from_metadata_v3_spec.rb
+++ b/spec/exe/matrix_from_metadata_v3_spec.rb
@@ -202,4 +202,42 @@ RSpec.describe 'matrix_from_metadata_v3' do
       )
     end
   end
+
+  context 'with --pe-include' do
+    let(:result) { run_matrix_from_metadata_v3(['--puppetlabs', '--pe-include']) }
+    let(:matrix) do
+      [
+        'matrix={',
+        '"platforms":[',
+        '{"label":"AmazonLinux-2","provider":"docker","arch":"x86_64","image":"litmusimage/amazonlinux:2","runner":"ubuntu-20.04"},',
+        '{"label":"AmazonLinux-2023","provider":"docker","arch":"x86_64","image":"litmusimage/amazonlinux:2023","runner":"ubuntu-20.04"},',
+        '{"label":"Ubuntu-18.04","provider":"docker","arch":"x86_64","image":"litmusimage/ubuntu:18.04","runner":"ubuntu-20.04"},',
+        '{"label":"Ubuntu-22.04","provider":"docker","arch":"x86_64","image":"litmusimage/ubuntu:22.04","runner":"ubuntu-latest"}',
+        '],',
+        '"collection":[',
+        '"puppet7-nightly","puppet8-nightly"',
+        ']',
+        '}'
+      ].join
+    end
+
+    it 'run successfully' do
+      expect(result.status_code).to eq 0
+    end
+
+    it 'generates the matrix with PE LTS versions' do
+      expect(result.stdout).to include(
+        '::warning::CentOS-6 no provisioner found',
+        '::warning::Ubuntu-14.04 no provisioner found',
+        '::group::matrix',
+        '::group::spec_matrix'
+      )
+      expect(github_output_content).to include(
+        '"collection":["2023.8.0-puppet_enterprise","2021.7.9-puppet_enterprise","puppet7-nightly","puppet8-nightly"'
+      )
+      expect(github_output_content).to include(
+        'spec_matrix={"include":[{"puppet_version":"~> 7.24","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Summary
This commit adds a feature to the `matrix_from_metadata_v3`  tool allowing users to pass the option `--pe-include` which will add Puppet Enterprise LTS versions to the collection matrix.

This is done by utilizing the `puppet_forge` gem to make a connection to the Forge API and retrieve a list of PE versions. 

The code in this commit will only add the LTS versions of PE to the collection matrix if the tool is passed the aforementioned option and the puppet version in the LTS falls within the supported range found in the metadata.

**Note**: Ideally this would add LTS and STS to the collection matrix. Once PE 2025.y is released, this could be easily updated to add the STS to the collection as well.

## Additional Context
My team is currently unable to utilize this tool to test our modules against PE. As such we are building our own matrix in separate workflows for PE and OSP. It would be nice to have a way to dynamically determine the LTS and STS PE versions and add them to the collection matrix.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [X] Manually verified.

```
# bundle exec rspec spec/exe/matrix_from_metadata_v3_spec.rb --format documentation

matrix_from_metadata_v3
  without arguments
    run successfully
    generates the matrix
  with puppetlabs GITHUB_REPOSITORY_OWNER
    run successfully
    generates the matrix
  with argument --puppetlabs
    run successfully
    generates the matrix
  with --exclude-platforms "ubuntu-18.04"
    run successfully
    generates the matrix without excluded platforms
  with --platform-exclude "ubuntu-(18.04|22.04)" --platform-exclude "redhat-[89]"
    run successfully
    generates the matrix without excluded platforms
  with --pe-include
    run successfully
    generates the matrix with PE LTS versions

Finished in 3.96 seconds (files took 0.26874 seconds to load)
12 examples, 0 failures
```