### PR TITLE
(feat) - Add Ubuntu-24.04 to matrix_from_metadata v2 and v3

### DIFF
--- a/exe/matrix.json
+++ b/exe/matrix.json
@@ -40,7 +40,8 @@
             },
             "Ubuntu": {
                 "20.04": { "x86_64": "ubuntu-2004-lts" },
-                "22.04": { "x86_64": "ubuntu-2204-lts", "arm": "ubuntu-2204-lts-arm64" }
+                "22.04": { "x86_64": "ubuntu-2204-lts", "arm": "ubuntu-2204-lts-arm64" },
+                "24.04": { "x86_64": "ubuntu-2404-lts", "arm": "ubuntu-2404-lts-arm64" }
             },
             "Windows": {
                 "2016": { "x86_64": "windows-2016" },
@@ -82,7 +83,8 @@
             "Ubuntu": {
                 "18.04": { "x86_64": "litmusimage/ubuntu:18.04" },
                 "20.04": { "x86_64": "litmusimage/ubuntu:20.04" },
-                "22.04": { "x86_64": "litmusimage/ubuntu:22.04" }
+                "22.04": { "x86_64": "litmusimage/ubuntu:22.04" },
+                "24.04": { "x86_64": "litmusimage/ubuntu:24.04" }
             }
         }
     },

--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -38,7 +38,8 @@ IMAGE_TABLE = {
 ARM_IMAGE_TABLE = {
   'Debian-12-arm' => 'debian-12-arm64',
   'RedHat-9-arm' => 'rhel-9-arm64',
-  'Ubuntu-22.04-arm' => 'ubuntu-2204-lts-arm64'
+  'Ubuntu-22.04-arm' => 'ubuntu-2204-lts-arm64',
+  'Ubuntu-24.04-arm' => 'ubuntu-2404-lts-arm64'
 }.freeze
 
 DOCKER_PLATFORMS = {
@@ -60,7 +61,8 @@ DOCKER_PLATFORMS = {
   'Scientific-7' => 'litmusimage/scientificlinux:7',
   'Ubuntu-18.04' => 'litmusimage/ubuntu:18.04',
   'Ubuntu-20.04' => 'litmusimage/ubuntu:20.04',
-  'Ubuntu-22.04' => 'litmusimage/ubuntu:22.04'
+  'Ubuntu-22.04' => 'litmusimage/ubuntu:22.04',
+  'Ubuntu-24.04' => 'litmusimage/ubuntu:24.04'
 }.freeze
 
 # This table uses the latest version in each collection for accurate
@@ -119,7 +121,8 @@ if ARGV.include?('--provision-service')
     'Debian-11' => 'debian-11',
     'Debian-12' => 'debian-12',
     'Ubuntu-20.04' => 'ubuntu-2004-lts',
-    'Ubuntu-22.04' => 'ubuntu-2204-lts'
+    'Ubuntu-22.04' => 'ubuntu-2204-lts',
+    'Ubuntu-24.04' => 'ubuntu-2404-lts'
   }
   updated_list = IMAGE_TABLE.dup.clone
   updated_list.merge!(updated_platforms)


### PR DESCRIPTION
## Summary
Add Ubuntu-24.04 (amd and arm) to matrix_from_metadata v2 and v3

## Additional Context

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
