### PR TITLE
Update to bolt 4

### DIFF
--- a/puppet_litmus.gemspec
+++ b/puppet_litmus.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   EOF
   spec.summary = 'Providing a simple command line tool for puppet content creators, to enable simple and complex test deployments.'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
-  spec.add_runtime_dependency 'bolt', '~> 3.0'
+  spec.add_runtime_dependency 'bolt', '~> 4.0'
   spec.add_runtime_dependency 'docker-api', '>= 1.34', '< 3.0.0'
   spec.add_runtime_dependency 'parallel'
   spec.add_runtime_dependency 'puppet-modulebuilder', '>= 0.3.0'


### PR DESCRIPTION
## Summary

puppet_litmus needs to be re-pointed to the latest bolt version 4.0.0 as it is currently pinned to the old.  This is breaking CI.  This PR fixes this.

Although all the CI tests are passing I did a manual verification of a puppet_litmus provision and test, which uses the underlying bolt.  See in comments

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
