### PR TITLE
fix: update matrix_from_metadata v2/v3 to install from public repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ Install Litmus as a gem by running `gem install puppet_litmus`.
 
 - Note if you choose to override the `litmus_inventory.yaml` location, please ensure that the directory structure you define exists.
 
+## Install a specific puppet agent version
+
+To install a specific version of the puppet agent, you can export the `PUPPET_VERSION` env var, like below:
+```
+export PUPPET_VERSION=8.8.1
+```
+
+When set, the `litmus:install_agent` rake task will install the specified version. The default is `latest`.
+
 ## matrix_from_metadata_v3
 
 matrix_from_metadata_v3 tool generates a github action matrix from the supported operating systems listed in the module's metadata.json.

--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -217,7 +217,7 @@ if metadata.key?('requirements') && metadata['requirements'].length.positive?
       # This assumes that such a boundary will always allow the latest actually existing puppet version of a release stream, trading off simplicity vs accuracy here.
       next unless Gem::Requirement.create(reqs).satisfied_by?(Gem::Version.new("#{collection[:puppet_maj_version]}.9999"))
 
-      matrix[:collection] << "puppet#{collection[:puppet_maj_version]}-nightly"
+      matrix[:collection] << "puppet#{collection[:puppet_maj_version]}"
 
       include_version = {
         8 => "~> #{collection[:puppet_maj_version]}.0",

--- a/exe/matrix_from_metadata_v3
+++ b/exe/matrix_from_metadata_v3
@@ -260,7 +260,7 @@ options[:metadata]['requirements']&.each do |req|
     # This assumes that such a boundary will always allow the latest actually existing puppet version of a release stream, trading off simplicity vs accuracy here.
     next unless gem_req.satisfied_by?(Gem::Version.new("#{collection['puppet'].to_i}.9999"))
 
-    matrix[:collection] << "puppet#{collection['puppet'].to_i}-nightly"
+    matrix[:collection] << "puppet#{collection['puppet'].to_i}"
 
     spec_matrix[:include] << {
       puppet_version: "~> #{collection['puppet']}",

--- a/lib/puppet_litmus/rake_helper.rb
+++ b/lib/puppet_litmus/rake_helper.rb
@@ -129,11 +129,11 @@ module PuppetLitmus::RakeHelper
 
   def install_agent(collection, targets, inventory_hash)
     include ::BoltSpec::Run
-    params = if collection.nil?
-               {}
-             else
-               { 'collection' => collection }
-             end
+    puppet_version = ENV.fetch('PUPPET_VERSION', nil)
+    params = {}
+    params['collection'] = collection  if collection
+    params['version'] = puppet_version if puppet_version
+
     raise "puppet_agent was not found in #{DEFAULT_CONFIG_DATA['modulepath']}, please amend the .fixtures.yml file" \
       unless File.directory?(File.join(DEFAULT_CONFIG_DATA['modulepath'], 'puppet_agent'))
 

--- a/spec/exe/matrix_from_metadata_v2_spec.rb
+++ b/spec/exe/matrix_from_metadata_v2_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
           '{"label":"Ubuntu-22.04-arm","provider":"provision_service","image":"ubuntu-2204-lts-arm64"}',
           '],',
           '"collection":[',
-          '"puppet7-nightly","puppet8-nightly"',
+          '"puppet7","puppet8"',
           ']',
           '}'
         ].join
@@ -75,7 +75,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
           '{"label":"Ubuntu-22.04-arm","provider":"provision_service","image":"ubuntu-2204-lts-arm64"}',
           '],',
           '"collection":[',
-          '"puppet7-nightly","puppet8-nightly"',
+          '"puppet7","puppet8"',
           ']',
           '}'
         ].join
@@ -114,7 +114,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
           '{"label":"Ubuntu-22.04-arm","provider":"provision_service","image":"ubuntu-2204-lts-arm64"}',
           '],',
           '"collection":[',
-          '"puppet7-nightly","puppet8-nightly"',
+          '"puppet7","puppet8"',
           ']',
           '}'
         ].join
@@ -153,7 +153,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
           '{"label":"Ubuntu-22.04","provider":"docker","image":"litmusimage/ubuntu:22.04"}',
           '],',
           '"collection":[',
-          '"puppet7-nightly","puppet8-nightly"',
+          '"puppet7","puppet8"',
           ']',
           '}'
         ].join

--- a/spec/exe/matrix_from_metadata_v3_spec.rb
+++ b/spec/exe/matrix_from_metadata_v3_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04","provider":"docker","arch":"x86_64","image":"litmusimage/ubuntu:22.04","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '"puppet8-nightly"',
+        '"puppet8"',
         ']',
         '}'
       ].join
@@ -63,7 +63,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04-arm","provider":"provision_service","arch":"arm","image":"ubuntu-2204-lts-arm64","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '"puppet8-nightly"',
+        '"puppet8"',
         ']',
         '}'
       ].join
@@ -103,7 +103,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04-arm","provider":"provision_service","arch":"arm","image":"ubuntu-2204-lts-arm64","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '"puppet8-nightly"',
+        '"puppet8"',
         ']',
         '}'
       ].join
@@ -142,7 +142,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04-arm","provider":"provision_service","arch":"arm","image":"ubuntu-2204-lts-arm64","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '"puppet8-nightly"',
+        '"puppet8"',
         ']',
         '}'
       ].join
@@ -175,7 +175,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '"platforms":[',
         '],',
         '"collection":[',
-        '"puppet8-nightly"',
+        '"puppet8"',
         ']',
         '}'
       ].join
@@ -215,7 +215,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04","provider":"docker","arch":"x86_64","image":"litmusimage/ubuntu:22.04","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '"puppet8-nightly"',
+        '"puppet8"',
         ']',
         '}'
       ].join
@@ -233,7 +233,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '::group::spec_matrix'
       )
       expect(github_output_content).to include(
-        '"collection":["2023.8.0-puppet_enterprise","2021.7.9-puppet_enterprise","puppet8-nightly"'
+        '"collection":["2023.8.0-puppet_enterprise","2021.7.9-puppet_enterprise","puppet8"'
       )
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 8.0","ruby_version":3.2}]}'


### PR DESCRIPTION
## Summary
Installs puppet agent from public repos, as oppose to nightly.

Also adds the ability to supply a specific puppet version to the install_agent task.

## Additional Context
![image](https://github.com/user-attachments/assets/7ac4ba1c-cc07-4b15-be97-cd3a7b5d2b2a)
![image](https://github.com/user-attachments/assets/7ae4a1a1-5d7b-41fc-9b80-f6b2574a2c35)

![image](https://github.com/user-attachments/assets/1c6261c9-20df-4165-944b-39477f2fab32)
## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
