### PR TITLE
breaking: mark matrix_from_metadata_v2 as deprecated in output

### DIFF
--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -229,6 +229,7 @@ if metadata.key?('requirements') && metadata['requirements'].length.positive?
   end
 end
 
+puts '::warning::matrix_from_metadata_v2 is now deprecated and will be removed in puppet_litmus v3, please migrate to matrix_from_metadata_v3.'
 # Set to defaults (all collections) if no matches are found
 matrix[:collection] = COLLECTION_TABLE.map { |collection| "puppet#{collection[:puppet_maj_version]}-nightly" } if matrix[:collection].empty?
 # Just to make sure there aren't any duplicates


### PR DESCRIPTION
## Summary
Mark matrix_from_metadata_v2 as deprecated in prepartion of puppet_litmus v2.
This will show as a warning in the github actions output, see example: https://github.com/puppetlabs/puppetlabs-peadm/actions/runs/14771597838/job/41472575236?pr=590#step:5:10

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
