### PR TITLE
feat: use puppetcore by default in matrix_from_metadata

### DIFF
--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -217,7 +217,7 @@ if metadata.key?('requirements') && metadata['requirements'].length.positive?
       # This assumes that such a boundary will always allow the latest actually existing puppet version of a release stream, trading off simplicity vs accuracy here.
       next unless Gem::Requirement.create(reqs).satisfied_by?(Gem::Version.new("#{collection[:puppet_maj_version]}.9999"))
 
-      matrix[:collection] << "puppet#{collection[:puppet_maj_version]}"
+      matrix[:collection] << "puppetcore#{collection[:puppet_maj_version]}"
 
       include_version = {
         8 => "~> #{collection[:puppet_maj_version]}.0",

--- a/exe/matrix_from_metadata_v3
+++ b/exe/matrix_from_metadata_v3
@@ -260,7 +260,7 @@ options[:metadata]['requirements']&.each do |req|
     # This assumes that such a boundary will always allow the latest actually existing puppet version of a release stream, trading off simplicity vs accuracy here.
     next unless gem_req.satisfied_by?(Gem::Version.new("#{collection['puppet'].to_i}.9999"))
 
-    matrix[:collection] << "puppet#{collection['puppet'].to_i}"
+    matrix[:collection] << "puppetcore#{collection['puppet'].to_i}"
 
     spec_matrix[:include] << {
       puppet_version: "~> #{collection['puppet']}",

--- a/spec/exe/matrix_from_metadata_v2_spec.rb
+++ b/spec/exe/matrix_from_metadata_v2_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
           '{"label":"Ubuntu-22.04-arm","provider":"provision_service","image":"ubuntu-2204-lts-arm64"}',
           '],',
           '"collection":[',
-          '"puppet7","puppet8"',
+          '"puppetcore7","puppetcore8"',
           ']',
           '}'
         ].join
@@ -75,7 +75,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
           '{"label":"Ubuntu-22.04-arm","provider":"provision_service","image":"ubuntu-2204-lts-arm64"}',
           '],',
           '"collection":[',
-          '"puppet7","puppet8"',
+          '"puppetcore7","puppetcore8"',
           ']',
           '}'
         ].join
@@ -114,7 +114,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
           '{"label":"Ubuntu-22.04-arm","provider":"provision_service","image":"ubuntu-2204-lts-arm64"}',
           '],',
           '"collection":[',
-          '"puppet7","puppet8"',
+          '"puppetcore7","puppetcore8"',
           ']',
           '}'
         ].join
@@ -153,7 +153,7 @@ RSpec.describe 'matrix_from_metadata_v2' do
           '{"label":"Ubuntu-22.04","provider":"docker","image":"litmusimage/ubuntu:22.04"}',
           '],',
           '"collection":[',
-          '"puppet7","puppet8"',
+          '"puppetcore7","puppetcore8"',
           ']',
           '}'
         ].join

--- a/spec/exe/matrix_from_metadata_v3_spec.rb
+++ b/spec/exe/matrix_from_metadata_v3_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04","provider":"docker","arch":"x86_64","image":"litmusimage/ubuntu:22.04","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '"puppet8"',
+        '"puppetcore8"',
         ']',
         '}'
       ].join
@@ -63,7 +63,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04-arm","provider":"provision_service","arch":"arm","image":"ubuntu-2204-lts-arm64","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '"puppet8"',
+        '"puppetcore8"',
         ']',
         '}'
       ].join
@@ -103,7 +103,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04-arm","provider":"provision_service","arch":"arm","image":"ubuntu-2204-lts-arm64","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '"puppet8"',
+        '"puppetcore8"',
         ']',
         '}'
       ].join
@@ -142,7 +142,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04-arm","provider":"provision_service","arch":"arm","image":"ubuntu-2204-lts-arm64","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '"puppet8"',
+        '"puppetcore8"',
         ']',
         '}'
       ].join
@@ -175,7 +175,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '"platforms":[',
         '],',
         '"collection":[',
-        '"puppet8"',
+        '"puppetcore8"',
         ']',
         '}'
       ].join
@@ -215,7 +215,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04","provider":"docker","arch":"x86_64","image":"litmusimage/ubuntu:22.04","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '"puppet8"',
+        '"puppetcore8"',
         ']',
         '}'
       ].join
@@ -233,7 +233,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '::group::spec_matrix'
       )
       expect(github_output_content).to include(
-        '"collection":["2023.8.0-puppet_enterprise","2021.7.9-puppet_enterprise","puppet8"'
+        '"collection":["2023.8.0-puppet_enterprise","2021.7.9-puppet_enterprise","puppetcore8"'
       )
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 8.0","ruby_version":3.2}]}'


### PR DESCRIPTION
## Summary
Updates matrix_from_metadata v2/v3 to use puppetcore by default

See example ci run https://github.com/puppetlabs/puppetlabs-peadm/actions/runs/14776268433/job/41485188480 (unsigned SLES 12 package has been raised with RE)

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
