### PR TITLE
(maint) - Bump expected PE LTS version in tests

### DIFF
--- a/spec/exe/matrix_from_metadata_v3_spec.rb
+++ b/spec/exe/matrix_from_metadata_v3_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '::group::spec_matrix'
       )
       expect(github_output_content).to include(
-        '"collection":["2023.8.0-puppet_enterprise","2021.7.9-puppet_enterprise","puppetcore8"'
+        '"collection":["2023.8.3-puppet_enterprise","2021.7.9-puppet_enterprise","puppetcore8"'
       )
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 8.0","ruby_version":3.2}]}'


### PR DESCRIPTION
## Summary
Bumps the expected PE LTS version return from matrix_from_metadata_v3 from 2023.8.0 to 2023.8.3 (just went LTS).

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
