### PR TITLE
(CAT-2433) Adds option to return latest agent build

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ in the project module root directory run `bundle exec matrix_from_metadata_v3`
 | --provision-include | NAME  | all               | Select provisioner |
 | --provision-exclude | NAME  | provision_service | Filter provisioner |
 | --nightly           |       |                   | Install from the nightly puppetcore images |
+| --latest-agent      |       |                   | Return the latest agent version as part of the matrix. Note: This changes how the collection is returned |
 
 > Refer to the [built-in matrix.json](https://github.com/puppetlabs/puppet_litmus/blob/main/exe/matrix.json) for a list of supported collection, provisioners, and platforms.
 

--- a/exe/matrix_from_metadata_v3
+++ b/exe/matrix_from_metadata_v3
@@ -163,6 +163,7 @@ begin
     opt.on('--provision-exclude NAME', String, "Filter provisioner (default: #{default_options[:'provision-exclude'] || 'none'})") { |o| options.provision_exclude.push(*o.split(',')) }
 
     opt.on('--nightly', TrueClass, 'Enable nightly builds') { |o| options.nightly = o }
+    opt.on('--latest-agent', TrueClass, 'Return the latest agent build as part of the matrix') { |o| options.latest_agent = o }
   end.parse!
 
   Action.config(debug: true) if options[:debug]
@@ -262,13 +263,31 @@ options[:metadata]['requirements']&.each do |req|
     # This assumes that such a boundary will always allow the latest actually existing puppet version of a release stream, trading off simplicity vs accuracy here.
     next unless gem_req.satisfied_by?(Gem::Version.new("#{collection['puppet'].to_i}.9999"))
 
+    # # If requested, return the latest agent version for the collection's puppet version
+    # # If not requested, return the value latest
+    agent_version = if options[:latest_agent] && collection['puppet'] != 'nightly'
+                      require 'net/http'
+                      require 'json'
+                      require 'uri'
+
+                      uri = URI('https://forgeapi.puppet.com/private/versions/puppet-agent')
+                      response = Net::HTTP.get_response(uri)
+                      json_data = JSON.parse(response.body)
+                      all_versions = json_data.keys
+                      versionx = all_versions.select { |v| v.start_with?("#{collection['puppet'].to_i}.") }
+                      versionx.sort_by { |v| Gem::Version.new(v) }.last # rubocop:disable Style/RedundantSort
+                    else
+                      'latest'
+                    end
+
     version = collection['puppet'].to_i
     prefix = 'puppetcore'
-    matrix[:collection] << if options[:nightly]
-                             "#{prefix}#{version}-nightly"
-                           else
-                             "#{prefix}#{version}"
-                           end
+    group = if options[:nightly]
+              "#{prefix}#{version}-nightly"
+            else
+              "#{prefix}#{version}"
+            end
+    matrix[:collection] << { collection: group, version: agent_version }
 
     spec_matrix[:include] << {
       puppet_version: "~> #{collection['puppet']}",

--- a/exe/matrix_from_metadata_v3
+++ b/exe/matrix_from_metadata_v3
@@ -169,6 +169,8 @@ begin
   Action.config(debug: true) if options[:debug]
   Action.config(notice: false) if options[:quiet] && !options[:debug]
 
+  raise OptionParser::InvalidArgument, 'latest-agent and pe-include are mutually exclusive options' if options[:latest_agent] && options[:pe_include]
+
   # validate provisioners
   options[:provision_include].select! do |p|
     options[:matrix]['provisioners'].key?(p) or raise OptionParser::InvalidArgument, "--provision-include '#{p}' not found in provisioners"
@@ -276,8 +278,6 @@ options[:metadata]['requirements']&.each do |req|
                       all_versions = json_data.keys
                       versionx = all_versions.select { |v| v.start_with?("#{collection['puppet'].to_i}.") }
                       versionx.sort_by { |v| Gem::Version.new(v) }.last # rubocop:disable Style/RedundantSort
-                    else
-                      'latest'
                     end
 
     version = collection['puppet'].to_i
@@ -287,7 +287,21 @@ options[:metadata]['requirements']&.each do |req|
             else
               "#{prefix}#{version}"
             end
-    matrix[:collection] << { collection: group, version: agent_version }
+    matrix[:collection] << if options[:latest_agent] && collection['puppet'] != 'nightly'
+                             require 'net/http'
+                             require 'json'
+                             require 'uri'
+
+                             uri = URI('https://forgeapi.puppet.com/private/versions/puppet-agent')
+                             response = Net::HTTP.get_response(uri)
+                             json_data = JSON.parse(response.body)
+                             all_versions = json_data.keys
+                             versionx = all_versions.select { |v| v.start_with?("#{collection['puppet'].to_i}.") }
+                             versionx.sort_by { |v| Gem::Version.new(v) }.last # rubocop:disable Style/RedundantSort
+                             { collection: group, version: agent_version }
+                           else
+                             group
+                           end
 
     spec_matrix[:include] << {
       puppet_version: "~> #{collection['puppet']}",

--- a/spec/exe/matrix_from_metadata_v3_spec.rb
+++ b/spec/exe/matrix_from_metadata_v3_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04","provider":"docker","arch":"x86_64","image":"litmusimage/ubuntu:22.04","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '"puppetcore8"',
+        '{"collection":"puppetcore8","version":"latest"}',
         ']',
         '}'
       ].join
@@ -63,7 +63,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04-arm","provider":"provision_service","arch":"arm","image":"ubuntu-2204-lts-arm64","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '"puppetcore8"',
+        '{"collection":"puppetcore8","version":"latest"}',
         ']',
         '}'
       ].join
@@ -103,7 +103,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04-arm","provider":"provision_service","arch":"arm","image":"ubuntu-2204-lts-arm64","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '"puppetcore8"',
+        '{"collection":"puppetcore8","version":"latest"}',
         ']',
         '}'
       ].join
@@ -142,7 +142,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04-arm","provider":"provision_service","arch":"arm","image":"ubuntu-2204-lts-arm64","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '"puppetcore8"',
+        '{"collection":"puppetcore8","version":"latest"}',
         ']',
         '}'
       ].join
@@ -175,7 +175,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '"platforms":[',
         '],',
         '"collection":[',
-        '"puppetcore8"',
+        '{"collection":"puppetcore8","version":"latest"}',
         ']',
         '}'
       ].join
@@ -215,7 +215,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04","provider":"docker","arch":"x86_64","image":"litmusimage/ubuntu:22.04","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '"puppetcore8"',
+        '{"collection":"puppetcore8","version":"latest"}',
         ']',
         '}'
       ].join
@@ -233,7 +233,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '::group::spec_matrix'
       )
       expect(github_output_content).to include(
-        '"collection":["2023.8.4-puppet_enterprise","2021.7.9-puppet_enterprise","puppetcore8"'
+        '"collection":["2023.8.4-puppet_enterprise","2021.7.9-puppet_enterprise",{"collection":"puppetcore8","version":"latest"}'
       )
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
@@ -257,7 +257,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04-arm","provider":"provision_service","arch":"arm","image":"ubuntu-2204-lts-arm64","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '"puppetcore8-nightly"',
+        '{"collection":"puppetcore8-nightly","version":"latest"}',
         ']',
         '}'
       ].join

--- a/spec/exe/matrix_from_metadata_v3_spec.rb
+++ b/spec/exe/matrix_from_metadata_v3_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04","provider":"docker","arch":"x86_64","image":"litmusimage/ubuntu:22.04","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '{"collection":"puppetcore8","version":"latest"}',
+        '"puppetcore8"',
         ']',
         '}'
       ].join
@@ -63,7 +63,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04-arm","provider":"provision_service","arch":"arm","image":"ubuntu-2204-lts-arm64","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '{"collection":"puppetcore8","version":"latest"}',
+        '"puppetcore8"',
         ']',
         '}'
       ].join
@@ -103,7 +103,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04-arm","provider":"provision_service","arch":"arm","image":"ubuntu-2204-lts-arm64","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '{"collection":"puppetcore8","version":"latest"}',
+        '"puppetcore8"',
         ']',
         '}'
       ].join
@@ -142,7 +142,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04-arm","provider":"provision_service","arch":"arm","image":"ubuntu-2204-lts-arm64","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '{"collection":"puppetcore8","version":"latest"}',
+        '"puppetcore8"',
         ']',
         '}'
       ].join
@@ -175,7 +175,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '"platforms":[',
         '],',
         '"collection":[',
-        '{"collection":"puppetcore8","version":"latest"}',
+        '"puppetcore8"',
         ']',
         '}'
       ].join
@@ -215,7 +215,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04","provider":"docker","arch":"x86_64","image":"litmusimage/ubuntu:22.04","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '{"collection":"puppetcore8","version":"latest"}',
+        '"puppetcore8"',
         ']',
         '}'
       ].join
@@ -233,7 +233,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '::group::spec_matrix'
       )
       expect(github_output_content).to include(
-        '"collection":["2023.8.4-puppet_enterprise","2021.7.9-puppet_enterprise",{"collection":"puppetcore8","version":"latest"}'
+        '"collection":["2023.8.4-puppet_enterprise","2021.7.9-puppet_enterprise","puppetcore8"'
       )
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
@@ -257,7 +257,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '{"label":"Ubuntu-22.04-arm","provider":"provision_service","arch":"arm","image":"ubuntu-2204-lts-arm64","runner":"ubuntu-latest"}',
         '],',
         '"collection":[',
-        '{"collection":"puppetcore8-nightly","version":"latest"}',
+        '"puppetcore8-nightly"',
         ']',
         '}'
       ].join
@@ -275,6 +275,27 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '::group::spec_matrix'
       )
       expect(github_output_content).to include(matrix)
+      expect(github_output_content).to include(
+        'spec_matrix={"include":[{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
+      )
+    end
+  end
+
+  context 'with argument --latest-agent' do
+    let(:result) { run_matrix_from_metadata_v3(['--puppetlabs', '--latest-agent']) }
+
+    it 'run successfully' do
+      expect(result.status_code).to eq 0
+    end
+
+    it 'generates the matrix' do
+      expect(result.stdout).to include(
+        '::warning::CentOS-6 no provisioner found',
+        '::warning::Ubuntu-14.04 no provisioner found',
+        '::group::matrix',
+        '::group::spec_matrix'
+      )
+      expect(github_output_content).to match(/{"collection":"puppetcore8","version":"\d+\.\d+\.\d+"}/)
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
       )


### PR DESCRIPTION
Adds a command-line option to specify whether the latest agent build should be included in the matrix. This is due to the Mac and Windows puppet_agent install tasks requiring a specific version when installing.
This updates the passed back information to the below format:
```
matrix={
  {"matrix":{"platforms":[
    {"label":"CentOS-7","provider":"docker","arch":"x86_64","image":"litmusimage/centos:7","runner":"ubuntu-22.04"},
    {"label":"CentOS-8","provider":"docker","arch":"x86_64","image":"litmusimage/centos:stream8","runner":"ubuntu-latest"},
    {"label":"OracleLinux-7","provider":"docker","arch":"x86_64","image":"litmusimage/oraclelinux:7","runner":"ubuntu-22.04"},
    {"label":"Scientific-7","provider":"docker","arch":"x86_64","image":"litmusimage/scientificlinux:7","runner":"ubuntu-22.04"},
    {"label":"Debian-10","provider":"docker","arch":"x86_64","image":"litmusimage/debian:10","runner":"ubuntu-22.04"},
    {"label":"Debian-11","provider":"docker","arch":"x86_64","image":"litmusimage/debian:11","runner":"ubuntu-latest"},
    {"label":"Debian-12","provider":"docker","arch":"x86_64","image":"litmusimage/debian:12","runner":"ubuntu-latest"},
    {"label":"Ubuntu-18.04","provider":"docker","arch":"x86_64","image":"litmusimage/ubuntu:18.04","runner":"ubuntu-22.04"},
    {"label":"Ubuntu-20.04","provider":"docker","arch":"x86_64","image":"litmusimage/ubuntu:20.04","runner":"ubuntu-latest"},
    {"label":"Ubuntu-22.04","provider":"docker","arch":"x86_64","image":"litmusimage/ubuntu:22.04","runner":"ubuntu-latest"},
    {"label":"Ubuntu-24.04","provider":"docker","arch":"x86_64","image":"litmusimage/ubuntu:24.04","runner":"ubuntu-latest"},
    {"label":"Rocky-8","provider":"docker","arch":"x86_64","image":"litmusimage/rockylinux:8","runner":"ubuntu-latest"},
    {"label":"AlmaLinux-8","provider":"docker","arch":"x86_64","image":"litmusimage/almalinux:8","runner":"ubuntu-latest"}
  ],
  "collection":[
    {"collection":"puppetcore8","version":"8.14.0"}
  ]
},
"spec_matrix":{
  "include":[
    {
      "puppet_version":"~> 8.0",
      "ruby_version":3.2
    }
  ]}
}
```
If the latest version is not requested it will instead return in the same manor as previously, ie.
```
  "collection":[
    "puppetcore8",
  ]
```
With the expectation that the user will resolve any conflicts from this on their end. This is to ensure backwards compatibility and not interfere with the work of other teams or with the specific code changes made for the pe team.

## Checklist
- [x] 🟢 Spec tests.
- [x] Manually verified.
