### PR TITLE
(CAT-2416) Address almalinux 8 provisioning issues

### DIFF
--- a/exe/matrix.json
+++ b/exe/matrix.json
@@ -86,7 +86,7 @@
     },
     "github_runner": {
         "docker": {
-            "^(AmazonLinux-2|(CentOS|OracleLinux|Scientific)-7|Ubuntu-18|Debian-10)": "ubuntu-22.04"
+            "^(AmazonLinux-2|(CentOS|OracleLinux|Scientific)-7|AlmaLinux-8|Ubuntu-18|Debian-10)": "ubuntu-22.04"
         }
     }
 }


### PR DESCRIPTION
Following an investigation on recent Almalinux 8 provisioning failures, it was found that there is a security policy issue that prevents ubuntu 24.04 runners from running the provisioning script for Almalinux
8. This commits defaults Almalinux 8 provisioning to always run on ubuntu 22.04 runners.

## Checklist
- [x] 🟢 Spec tests.
- [ ] Manually verified.
