### PR TITLE
(CAT-2427) Address 9th gen auth failures

### DIFF
--- a/exe/matrix.json
+++ b/exe/matrix.json
@@ -86,7 +86,7 @@
     },
     "github_runner": {
         "docker": {
-            "^(AmazonLinux-2|(CentOS|OracleLinux|Scientific)-7|AlmaLinux-8|Ubuntu-18|Debian-10)": "ubuntu-22.04"
+            "^(AmazonLinux-2|(CentOS|OracleLinux|Scientific)-7|(AlmaLinux|OracleLinux|RockyLinux|CentOS)-9|AlmaLinux-8|Fedora-36|Ubuntu-18|Debian-10)": "ubuntu-22.04"
         }
     }
 }


### PR DESCRIPTION
Following investigation of authentication failures for 9th gen OSs, it was found that the cause was the usage of ubuntu 24.04 runners and their stricter security policies. This commit updates the matrix.json file to pin 9th gen to older runners to avoid these conflicts.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
