### PR TITLE
(MAINT) Fix Rocky typo in matrix.json

### DIFF
--- a/exe/matrix.json
+++ b/exe/matrix.json
@@ -86,7 +86,7 @@
     },
     "github_runner": {
         "docker": {
-            "^(AmazonLinux-2|(CentOS|OracleLinux|Scientific)-7|(AlmaLinux|OracleLinux|RockyLinux|CentOS)-9|AlmaLinux-8|Fedora-36|Ubuntu-18|Debian-10)": "ubuntu-22.04"
+            "^(AmazonLinux-2|(CentOS|OracleLinux|Scientific)-7|(AlmaLinux|OracleLinux|Rocky|CentOS)-9|AlmaLinux-8|Fedora-36|Ubuntu-18|Debian-10)": "ubuntu-22.04"
         }
     }
 }


### PR DESCRIPTION
The matrix identifies RockyLinux by its short name 'Rocky'. Adjusting this name in a conditional to ensure ubuntu 22.04 usage during provisioning.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
