### PR TITLE
(CAT-2463) Support bolt 5.0

### DIFF
--- a/puppet_litmus.gemspec
+++ b/puppet_litmus.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   EOF
   spec.summary = 'Providing a simple command line tool for puppet content creators, to enable simple and complex test deployments.'
   spec.required_ruby_version = Gem::Requirement.new('>= 3.1.0')
-  spec.add_runtime_dependency 'bolt', '~> 4.0'
+  spec.add_runtime_dependency 'bolt', '>= 4.0', '< 6.0'
   spec.add_runtime_dependency 'docker-api', '>= 1.34', '< 3.0.0'
   spec.add_runtime_dependency 'parallel'
   spec.add_runtime_dependency 'puppet-modulebuilder', '>= 0.3.0'


### PR DESCRIPTION
# Fix bolt dependency constraint to support bolt 5.x

## Problem

puppet_litmus causes a dependency failure when trying to use bolt 5.0.0 due to an overly restrictive dependency constraint:

```bash
Because puppet_litmus >= 1.6.1 depends on bolt ~> 4.0
  and Gemfile depends on puppet_litmus ~> 2.0,
  bolt ~> 4.0 is required.
So, because Gemfile depends on bolt ~> 5.0,
  version solving has failed.
```

The current gemspec constraint `bolt ~> 4.0` only allows bolt version 4.x, preventing users from upgrading to bolt 5.x.

## Solution

Updated the bolt dependency constraint from `~> 4.0` to `>= 4.0, < 6.0` to:

- Maintain backward compatibility with bolt 4.x
- Allow forward compatibility with bolt 5.x
- Prevent breaking changes from bolt 6.x (when it's released)

## Testing

Manual testing confirms backward compatibility and forward compatibility (see comments below for more details):

**With bolt 4.0.0:**

```text
bolt (4.0.0)
puppet_litmus (2.3.2)
```

**With bolt 5.0.0:**

```text
bolt (5.0.0) 
puppet_litmus (2.3.2)
```

Both configurations resolve dependencies successfully without errors, demonstrating that this change maintains backward compatibility while enabling use of newer bolt versions.