### PR TITLE
(PA-8419) Add Debian 13 support to provisioner matrix

### DIFF
--- a/exe/matrix.json
+++ b/exe/matrix.json
@@ -23,7 +23,8 @@
             "Debian": {
                 "10": { "x86_64": "debian-10" },
                 "11": { "x86_64": "debian-11" },
-                "12": { "x86_64": "debian-12", "arm": "debian-12-arm64" }
+                "12": { "x86_64": "debian-12", "arm": "debian-12-arm64" },
+                "13": { "x86_64": "debian-13" }
             },
             "RedHat": {
                 "7": { "x86_64": "rhel-7" },
@@ -67,7 +68,8 @@
             "Debian": {
                 "10": { "x86_64": "litmusimage/debian:10" },
                 "11": { "x86_64": "litmusimage/debian:11" },
-                "12": { "x86_64": "litmusimage/debian:12" }
+                "12": { "x86_64": "litmusimage/debian:12" },
+                "13": { "x86_64": "litmusimage/debian:13" }
             },
             "OracleLinux": {
                 "7": { "x86_64": "litmusimage/oraclelinux:7" },

--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -57,6 +57,7 @@ DOCKER_PLATFORMS = {
   'Debian-10' => 'litmusimage/debian:10',
   'Debian-11' => 'litmusimage/debian:11',
   'Debian-12' => 'litmusimage/debian:12',
+  'Debian-13' => 'litmusimage/debian:13',
   'OracleLinux-7' => 'litmusimage/oraclelinux:7',
   'OracleLinux-8' => 'litmusimage/oraclelinux:8',
   'OracleLinux-9' => 'litmusimage/oraclelinux:9',
@@ -122,6 +123,7 @@ if ARGV.include?('--provision-service')
     'Debian-10' => 'debian-10',
     'Debian-11' => 'debian-11',
     'Debian-12' => 'debian-12',
+    'Debian-13' => 'debian-13',
     'Ubuntu-20.04' => 'ubuntu-2004-lts',
     'Ubuntu-22.04' => 'ubuntu-2204-lts',
     'Ubuntu-24.04' => 'ubuntu-2404-lts'


### PR DESCRIPTION
Add Debian 13 to provisioner matrix

Register Debian 13 (trixie) in both the v3 matrix catalog
(exe/matrix.json) and the legacy v2 script (exe/matrix_from_metadata_v2),
covering the docker backend (litmusimage/debian:13) and the
provision_service/GCP backend (debian-13).

Without this entry, matrix_from_metadata_v3 emits
"Debian-13 no provisioner found" and silently drops the platform
from the generated acceptance matrix even when a module declares
Debian 13 in its metadata.json.

Requires litmusimage/debian:13 to be published on Docker Hub and a
debian-13 image to be available via the GCP provisioner facade.


## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
