### PR TITLE
(CAT-2588) Enable public puppet fall back

### DIFF
--- a/exe/matrix_from_metadata_v3
+++ b/exe/matrix_from_metadata_v3
@@ -281,12 +281,12 @@ options[:metadata]['requirements']&.each do |req|
                     end
 
     version = collection['puppet'].to_i
-    prefix = 'puppetcore'
-    group = if options[:nightly]
-              "#{prefix}#{version}-nightly"
-            else
-              "#{prefix}#{version}"
-            end
+    forge_token = ENV.fetch('PUPPET_FORGE_TOKEN', nil)
+    prefix = forge_token ? 'puppetcore' : 'puppet'
+    nightly = options[:nightly] && forge_token
+    Action.warning('--nightly ignored: PUPPET_FORGE_TOKEN is not set, falling back to public puppet collection') \
+      if options[:nightly] && !forge_token
+    group = nightly ? "#{prefix}#{version}-nightly" : "#{prefix}#{version}"
     matrix[:collection] << if options[:latest_agent] && collection['puppet'] != 'nightly'
                              require 'net/http'
                              require 'json'

--- a/spec/exe/matrix_from_metadata_v3_spec.rb
+++ b/spec/exe/matrix_from_metadata_v3_spec.rb
@@ -301,6 +301,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
     end
 
     it 'falls back to public puppet collection' do
+      result
       expect(github_output_content).to include('"collection":["puppet8"]')
     end
   end

--- a/spec/exe/matrix_from_metadata_v3_spec.rb
+++ b/spec/exe/matrix_from_metadata_v3_spec.rb
@@ -232,9 +232,8 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '::group::matrix',
         '::group::spec_matrix'
       )
-      expect(github_output_content).to include(
-        /"collection":\["\d{4}\.\d\.\d-puppet_enterprise","\d{4}\.\d\.\d-puppet_enterprise","puppetcore8"/
-      )
+      expect(github_output_content).to match(/"collection":\["\d{4}\.\d\.\d-puppet_enterprise","\d{4}\.\d\.\d-puppet_enterprise","puppetcore8"/)
+
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
       )
@@ -242,7 +241,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
   end
 
   context 'with argument --nightly' do
-    let(:result) { run_matrix_from_metadata_v3(['--puppetlabs', '--nightly']) }
+    let(:result) { run_matrix_from_metadata_v3(['--puppetlabs', '--nightly'], env: { 'PUPPET_FORGE_TOKEN' => 'fake_token' }) }
     let(:matrix) do
       [
         'matrix={',
@@ -281,6 +280,31 @@ RSpec.describe 'matrix_from_metadata_v3' do
     end
   end
 
+  context 'with --nightly and no PUPPET_FORGE_TOKEN' do
+    let(:result) { run_matrix_from_metadata_v3(['--nightly'], env: { 'PUPPET_FORGE_TOKEN' => nil }) }
+
+    it 'run successfully' do
+      expect(result.status_code).to eq 0
+    end
+
+    it 'falls back to public puppet collection with a warning' do
+      expect(result.stdout).to include('--nightly ignored: PUPPET_FORGE_TOKEN is not set, falling back to public puppet collection')
+      expect(github_output_content).to include('"collection":["puppet8"]')
+    end
+  end
+
+  context 'without PUPPET_FORGE_TOKEN' do
+    let(:result) { run_matrix_from_metadata_v3(['--puppetlabs'], env: { 'PUPPET_FORGE_TOKEN' => nil }) }
+
+    it 'run successfully' do
+      expect(result.status_code).to eq 0
+    end
+
+    it 'falls back to public puppet collection' do
+      expect(github_output_content).to include('"collection":["puppet8"]')
+    end
+  end
+
   context 'with argument --latest-agent' do
     let(:result) { run_matrix_from_metadata_v3(['--puppetlabs', '--latest-agent']) }
 
@@ -296,6 +320,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '::group::spec_matrix'
       )
       expect(github_output_content).to match(/{"collection":"puppetcore8","version":"\d+\.\d+\.\d+"}/)
+
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 8.0","ruby_version":3.2}]}'
       )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,14 +38,14 @@ def run_matrix_from_metadata_v2(options = {})
   )
 end
 
-def run_matrix_from_metadata_v3(options = [])
+def run_matrix_from_metadata_v3(options = [], env: {})
   command = %w[bundle exec ./exe/matrix_from_metadata_v3]
   unless options.include? '--metadata'
     options << '--metadata'
     options << File.join(File.dirname(__FILE__), 'exe', 'fake_metadata.json')
   end
   command += options
-  result = Open3.capture3(*command)
+  result = Open3.capture3(env, *command)
   OpenStruct.new(
     stdout: result[0],
     stderr: result[1],


### PR DESCRIPTION
Passing --nightly flag without a puppet forge token warns and switches to the non-nightly public collection instead of erroring.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
