### PR TITLE
Fix PE LTS version regex to allow multi-digit version components

### DIFF
--- a/spec/exe/matrix_from_metadata_v3_spec.rb
+++ b/spec/exe/matrix_from_metadata_v3_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '::group::matrix',
         '::group::spec_matrix'
       )
-      expect(github_output_content).to match(/"collection":\[(?:"\d{4}\.\d\.\d-puppet_enterprise",)+"puppetcore8","puppetcore9"/)
+      expect(github_output_content).to match(/"collection":\[(?:"\d{4}\.\d+\.\d+-puppet_enterprise",)+"puppetcore8","puppetcore9"/)
       expect(github_output_content).to include(
         'spec_matrix={"include":[{"puppet_version":"~> 8.0","ruby_version":3.2},{"puppet_version":"~> 9.0","ruby_version":4.0}]}'
       )


### PR DESCRIPTION
## Problem

The nightly `spec` jobs have started failing on `main` (e.g. [run 29789970357](https://github.com/puppetlabs/puppet_litmus/actions/runs/29789970357)) with a single failing example:

```
spec/exe/matrix_from_metadata_v3_spec.rb:235
  matrix_from_metadata_v3 with --pe-include generates the matrix with PE LTS versions
```

The `--pe-include` path fetches PE LTS tracks live from `forgeapi.puppet.com/private/versions/pe` and adds the latest qualifying track to the collection matrix. The current Puppet 8 LTS track has rolled over to **`2023.8.10`**, producing:

```
"collection":["2023.8.10-puppet_enterprise","puppetcore8","puppetcore9"]
```

The assertion regex only allowed a **single-digit patch** (`\d{4}\.\d\.\d`), so `2023.8.10` (two-digit patch) no longer matched. No code changed — an external PE version bump tripped a too-strict test.

## Fix

Loosen the version fragment to allow multi-digit minor/patch components:

```diff
-/"collection":\[(?:"\d{4}\.\d\.\d-puppet_enterprise",)+"puppetcore8","puppetcore9"/
+/"collection":\[(?:"\d{4}\.\d+\.\d+-puppet_enterprise",)+"puppetcore8","puppetcore9"/
```

Verified the new regex matches the current `2023.8.10` output and remains compatible with prior single-digit-patch versions (e.g. `2023.8.9`).

## Follow-up (not in this PR)

This spec makes a **live, unstubbed HTTP call** to the Forge private API, so it is inherently non-deterministic and will keep breaking on future PE releases or endpoint issues. A follow-up should stub `/private/versions/pe` (webmock) with a fixture and assert a known value, making the test hermetic. Happy to raise that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)