### PR TITLE
(MODULES-11700) Add --collection-platform-exclude to matrix_from_metadata_v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ in the project module root directory run `bundle exec matrix_from_metadata_v3`
 | --puppet-exclude    | MAJOR |                   | Filter puppet major version |
 | --platform-include  | REGEX |                   | Select platform |
 | --platform-exclude  | REGEX |                   | Filter platform |
+| --collection-platform-exclude | MAJOR:REGEX | | Filter a platform for one puppet major only, emitted as a GitHub Actions matrix exclude so the platform stays in other collections. Repeatable |
 | --arch-include      | REGEX |                   | Select architecture |
 | --arch-exclude      | REGEX |                   | Filter architecture |
 | --provision-prefer  | NAME  | docker            | Prefer provisioner |
@@ -87,6 +88,10 @@ in the project module root directory run `bundle exec matrix_from_metadata_v3`
 * Exclude platforms
   ```sh
   matrix_from_metadata_v3 --platform-exclude redhat-7 --platform-exclude ubuntu-18.04
+  ```
+* Exclude a platform for one puppet major only (kept in other collections). E.g. ubuntu-20.04 has no Puppet 9 agent but is valid on Puppet 8:
+  ```sh
+  matrix_from_metadata_v3 --nightly --collection-platform-exclude 9:ubuntu-20.04
   ```
 * Exclude architecture
   ```sh

--- a/exe/matrix_from_metadata_v3
+++ b/exe/matrix_from_metadata_v3
@@ -86,6 +86,7 @@ options = OpenStruct.new(
   puppet_include: [],
   platform_exclude: [],
   platform_include: [],
+  collection_platform_exclude: [],
   arch_include: [],
   arch_exclude: [],
   provision_prefer: [],
@@ -154,6 +155,16 @@ begin
 
     opt.on('--platform-include REGEX', Regexp, 'Select platform') { |o| options.platform_include << o }
     opt.on('--platform-exclude REGEX', Regexp, 'Filter platform') { |o| options.platform_exclude << o }
+
+    opt.on('--collection-platform-exclude SPEC', String,
+           'Filter a platform for one puppet major only, as MAJOR:PLATFORM_REGEX (e.g. 9:ubuntu-20.04). ' \
+           'Emitted as a GitHub Actions matrix exclude so the platform stays in other collections. Repeatable.') do |o|
+      major, regex = o.split(':', 2)
+      raise OptionParser::InvalidArgument, "--collection-platform-exclude '#{o}' must be MAJOR:PLATFORM_REGEX" \
+        if regex.nil? || regex.empty? || major !~ /\A\d+\z/
+
+      options.collection_platform_exclude << { major: major.to_i, platform: Regexp.new(regex, Regexp::IGNORECASE) }
+    end
 
     opt.on('--arch-include REGEX', Regexp, 'Select architecture') { |o| options.arch_include << o }
     opt.on('--arch-exclude REGEX', Regexp, 'Filter architecture') { |o| options.arch_exclude << o }
@@ -368,6 +379,29 @@ options[:metadata]['operatingsystem_support'].each do |os_sup|
       matrix[:platforms].push(*os_ver_platforms)
     end
   end
+end
+
+# Exclude specific platform x collection combinations (e.g. an OS a given puppet
+# major ships no agent package for, such as ubuntu-20.04 on puppet 9). The platform
+# and collection remain valid on their own, so this is emitted as a GitHub Actions
+# matrix `exclude` that only drops the matching combinations.
+unless options[:collection_platform_exclude].empty?
+  exclude = []
+  matrix[:collection].each do |coll|
+    coll_name = coll.is_a?(Hash) ? coll[:collection] : coll
+    major = coll_name.to_s[/\d+/]&.to_i
+    next if major.nil?
+
+    matrix[:platforms].each do |platform|
+      next unless options[:collection_platform_exclude].any? do |spec|
+        spec[:major] == major && platform[:label].match?(spec[:platform])
+      end
+
+      Action.notice("collection-platform-exclude filtered #{platform[:label]} x #{coll_name}")
+      exclude << { platforms: platform, collection: coll }
+    end
+  end
+  matrix[:exclude] = exclude unless exclude.empty?
 end
 
 Action.group('matrix', matrix, pretty: true).group('spec_matrix', spec_matrix, pretty: true) if Action.type == 'github' && Action.notice

--- a/exe/matrix_from_metadata_v3
+++ b/exe/matrix_from_metadata_v3
@@ -163,7 +163,12 @@ begin
       raise OptionParser::InvalidArgument, "--collection-platform-exclude '#{o}' must be MAJOR:PLATFORM_REGEX" \
         if regex.nil? || regex.empty? || major !~ /\A\d+\z/
 
-      options.collection_platform_exclude << { major: major.to_i, platform: Regexp.new(regex, Regexp::IGNORECASE) }
+      begin
+        platform = Regexp.new(regex, Regexp::IGNORECASE)
+      rescue RegexpError => e
+        raise OptionParser::InvalidArgument, "--collection-platform-exclude '#{o}' has an invalid PLATFORM_REGEX: #{e.message}"
+      end
+      options.collection_platform_exclude << { major: major.to_i, platform: platform }
     end
 
     opt.on('--arch-include REGEX', Regexp, 'Select architecture') { |o| options.arch_include << o }

--- a/exe/matrix_from_metadata_v3
+++ b/exe/matrix_from_metadata_v3
@@ -168,7 +168,7 @@ begin
       rescue RegexpError => e
         raise OptionParser::InvalidArgument, "--collection-platform-exclude '#{o}' has an invalid PLATFORM_REGEX: #{e.message}"
       end
-      options.collection_platform_exclude << { major: major.to_i, platform: platform }
+      options.collection_platform_exclude << { major: major.to_i, platform: }
     end
 
     opt.on('--arch-include REGEX', Regexp, 'Select architecture') { |o| options.arch_include << o }

--- a/spec/exe/matrix_from_metadata_v3_spec.rb
+++ b/spec/exe/matrix_from_metadata_v3_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'json'
 
 RSpec.describe 'matrix_from_metadata_v3' do
   let(:github_output) { Tempfile.new('github_output') }
@@ -350,11 +351,13 @@ RSpec.describe 'matrix_from_metadata_v3' do
 
     it 'emits a matrix exclude for only the matching platform x collection' do
       result
-      expect(github_output_content).to include(
-        '"exclude":[' \
-        '{"platforms":{"label":"Ubuntu-18.04","provider":"docker","arch":"x86_64",' \
-        '"image":"litmusimage/ubuntu:18.04","runner":"ubuntu-22.04"},' \
-        '"collection":"puppetcore9"}]'
+      matrix = JSON.parse(github_output_content[/^matrix=(.+)$/, 1])
+      expect(matrix['exclude']).to contain_exactly(
+        'platforms' => {
+          'label' => 'Ubuntu-18.04', 'provider' => 'docker', 'arch' => 'x86_64',
+          'image' => 'litmusimage/ubuntu:18.04', 'runner' => 'ubuntu-22.04'
+        },
+        'collection' => 'puppetcore9'
       )
     end
 

--- a/spec/exe/matrix_from_metadata_v3_spec.rb
+++ b/spec/exe/matrix_from_metadata_v3_spec.rb
@@ -349,6 +349,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
     end
 
     it 'emits a matrix exclude for only the matching platform x collection' do
+      result
       expect(github_output_content).to include(
         '"exclude":[' \
         '{"platforms":{"label":"Ubuntu-18.04","provider":"docker","arch":"x86_64",' \
@@ -360,6 +361,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
     it 'keeps the platform and the collection usable in other combinations' do
       # Ubuntu-18.04 is still a platform and puppetcore9 is still a collection;
       # only the single pair is excluded (so Ubuntu-18.04 still runs on puppetcore8).
+      result
       expect(github_output_content).to include('{"label":"Ubuntu-18.04","provider":"docker",')
       expect(github_output_content).to include('"collection":["puppetcore8","puppetcore9"]')
     end

--- a/spec/exe/matrix_from_metadata_v3_spec.rb
+++ b/spec/exe/matrix_from_metadata_v3_spec.rb
@@ -335,4 +335,48 @@ RSpec.describe 'matrix_from_metadata_v3' do
       )
     end
   end
+
+  context 'with --collection-platform-exclude' do
+    let(:result) do
+      run_matrix_from_metadata_v3(
+        ['--collection-platform-exclude', '9:ubuntu-18.04'],
+        env: { 'PUPPET_FORGE_TOKEN' => 'fake' },
+      )
+    end
+
+    it 'runs successfully' do
+      expect(result.status_code).to eq 0
+    end
+
+    it 'emits a matrix exclude for only the matching platform x collection' do
+      expect(github_output_content).to include(
+        '"exclude":[' \
+        '{"platforms":{"label":"Ubuntu-18.04","provider":"docker","arch":"x86_64",' \
+        '"image":"litmusimage/ubuntu:18.04","runner":"ubuntu-22.04"},' \
+        '"collection":"puppetcore9"}]',
+      )
+    end
+
+    it 'keeps the platform and the collection usable in other combinations' do
+      # Ubuntu-18.04 is still a platform and puppetcore9 is still a collection;
+      # only the single pair is excluded (so Ubuntu-18.04 still runs on puppetcore8).
+      expect(github_output_content).to include('{"label":"Ubuntu-18.04","provider":"docker",')
+      expect(github_output_content).to include('"collection":["puppetcore8","puppetcore9"]')
+    end
+
+    it 'logs the exclusion' do
+      expect(result.stdout).to include('::notice::collection-platform-exclude filtered Ubuntu-18.04 x puppetcore9')
+    end
+  end
+
+  context 'with an invalid --collection-platform-exclude spec' do
+    let(:result) do
+      run_matrix_from_metadata_v3(['--collection-platform-exclude', 'ubuntu-18.04'])
+    end
+
+    it 'fails with a helpful error' do
+      expect(result.status_code).not_to eq 0
+      expect(result.stdout).to include("--collection-platform-exclude 'ubuntu-18.04' must be MAJOR:PLATFORM_REGEX")
+    end
+  end
 end

--- a/spec/exe/matrix_from_metadata_v3_spec.rb
+++ b/spec/exe/matrix_from_metadata_v3_spec.rb
@@ -340,7 +340,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
     let(:result) do
       run_matrix_from_metadata_v3(
         ['--collection-platform-exclude', '9:ubuntu-18.04'],
-        env: { 'PUPPET_FORGE_TOKEN' => 'fake' },
+        env: { 'PUPPET_FORGE_TOKEN' => 'fake' }
       )
     end
 
@@ -353,7 +353,7 @@ RSpec.describe 'matrix_from_metadata_v3' do
         '"exclude":[' \
         '{"platforms":{"label":"Ubuntu-18.04","provider":"docker","arch":"x86_64",' \
         '"image":"litmusimage/ubuntu:18.04","runner":"ubuntu-22.04"},' \
-        '"collection":"puppetcore9"}]',
+        '"collection":"puppetcore9"}]'
       )
     end
 


### PR DESCRIPTION
# Add `--collection-platform-exclude` to matrix_from_metadata_v3

## Problem

`matrix_from_metadata_v3` emits `matrix.platforms` and `matrix.collection` as two
independent lists. The consuming GitHub Actions workflow uses them as a
`strategy.matrix`, i.e. a full cartesian product — every platform is tested
against every collection.

That breaks down when a platform is valid for one Puppet major but not another.
Example: Ubuntu 20.04 (focal) is supported by Puppet 8 but dropped by Puppet 9,
so `ubuntu-20.04 × puppetcore9-nightly` fails at agent install (404 — no focal
package for Puppet 9). Today the only levers are:

- `--platform-exclude` — removes the platform from **all** collections (would also
  drop the valid Puppet 8 coverage), and
- `--puppet-exclude` — removes a Puppet major from **all** platforms.

Neither can drop a single platform×collection cell.

## Change

Add a repeatable `--collection-platform-exclude MAJOR:PLATFORM_REGEX` flag. It emits
a GitHub Actions matrix `exclude:` entry for each matching platform×collection
combination, leaving both the platform and the collection available for every other
combination.

```
# ubuntu-20.04 stays in the Puppet 8 lane, dropped only from Puppet 9
matrix_from_metadata_v3 --nightly --collection-platform-exclude 9:ubuntu-20.04
```

`MAJOR` is the Puppet major (integer, matched against the collection, so it applies
to nightly and non-nightly alike). `PLATFORM_REGEX` is matched case-insensitively
against the platform label. Invalid specs (missing `MAJOR:` or non-numeric major)
raise an `OptionParser::InvalidArgument`.

No behaviour change unless the flag is supplied.

## Notes / review points

- The `exclude` entry references the full `platforms` object and the `collection`
  value verbatim from the generated lists, so GitHub Actions matches them by
  deep-equality. This relies on GHA's `exclude` supporting object-valued matrix
  dimensions (the workflow already treats `platforms`/`collection` as objects).
  Worth a smoke-test in a real run; if it proves unreliable, the alternative is to
  emit a single `include:` list instead of two independent dimensions.
- Alternative considered: deriving the exclusions automatically from AIO
  support data (which Puppet major ships which OS). That needs a data source the
  tool doesn't currently carry; the explicit flag is minimal and mirrors the
  existing `--platform-exclude` idiom. Auto-derivation can layer on later.

## Tests

Adds examples to `spec/exe/matrix_from_metadata_v3_spec.rb` covering: the emitted
`exclude` for the matching pair, the platform/collection remaining available
elsewhere, the `::notice` log line, and the invalid-spec error path.
