### PR TITLE
(MODULES-11934) Point Ubuntu 20.04 at the Pro image family

### DIFF
--- a/exe/matrix.json
+++ b/exe/matrix.json
@@ -41,7 +41,7 @@
                 "15":  { "x86_64": "sles-15" }
             },
             "Ubuntu": {
-                "20.04": { "x86_64": "ubuntu-2004-lts" },
+                "20.04": { "x86_64": "ubuntu-os-pro-cloud/ubuntu-pro-2004-lts" },
                 "22.04": { "x86_64": "ubuntu-2204-lts", "arm": "ubuntu-2204-lts-arm64" },
                 "24.04": { "x86_64": "ubuntu-2404-lts", "arm": "ubuntu-2404-lts-arm64" }
             },

--- a/exe/matrix_from_metadata_v2
+++ b/exe/matrix_from_metadata_v2
@@ -125,7 +125,7 @@ if ARGV.include?('--provision-service')
     'Debian-11' => 'debian-11',
     'Debian-12' => 'debian-12',
     'Debian-13' => 'debian-13',
-    'Ubuntu-20.04' => 'ubuntu-2004-lts',
+    'Ubuntu-20.04' => 'ubuntu-os-pro-cloud/ubuntu-pro-2004-lts',
     'Ubuntu-22.04' => 'ubuntu-2204-lts',
     'Ubuntu-24.04' => 'ubuntu-2404-lts'
   }


### PR DESCRIPTION
The `provision_service` matrix maps Ubuntu 20.04 to the GCP image family `ubuntu-2004-lts`. That family no longer exists, so provisioning fails before any VM is created and the facade surfaces it as an opaque HTTP 500:

```
Provisioning ubuntu-2004-lts using provision_service provisioner.
rake aborted!
provisioning of ubuntu-2004-lts failed.
  localhost: {"_error"=>{"kind"=>"provision_service/service_error",
  "msg"=>"provision service returned an error", "code"=>"500",
  "body"=>"<h1>Internal Server Error</h1>"}}
```

## Cause

`ubuntu-2004-lts` resolved against `ubuntu-os-cloud`. When Ubuntu 20.04 left standard support on 2025-05-31, Canonical stopped publishing focal there and moved it to the Pro project. Every surviving focal family now lives in `ubuntu-os-pro-cloud`:

```
NAME                                     PROJECT              FAMILY                       STATUS
ubuntu-pro-2004-focal-v20260826          ubuntu-os-pro-cloud  ubuntu-pro-2004-lts          READY
ubuntu-minimal-pro-2004-focal-v20260826  ubuntu-os-pro-cloud  ubuntu-minimal-pro-2004-lts  READY
ubuntu-pro-fips-2004-focal-v20260821     ubuntu-os-pro-cloud  ubuntu-pro-fips-2004-lts     READY
```

**Focal itself is not dead** — `archive.ubuntu.com/dists/focal` → 200 and `security.ubuntu.com/dists/focal-security` → 200, with ESM running to April 2030. Only the standard-project image family went away, so this is worth fixing rather than dropping the platform.

## The change

Uses the `{project}/{family}` form already present in this file for `almalinux-cloud/almalinux-8` and `rocky-linux-cloud/rocky-linux-8`:

```diff
- "20.04": { "x86_64": "ubuntu-2004-lts" },
+ "20.04": { "x86_64": "ubuntu-os-pro-cloud/ubuntu-pro-2004-lts" },
```

provision_service's `backend/templates/gcp_template.tofu.erb` passes the string straight into `boot_disk.initialize_params.image` and sanitises slashes for the Terraform resource label (`gcp_image.gsub(%r{/}, '-')`), so the slash form is supported by design.

`ubuntu-pro-2004-focal-v20260826` is dated 2026-08-26, so this tracks an actively built family and keeps receiving patches — it is not a frozen dated pin.

## Impact

Only modules preferring `provision_service` are affected. In practice that is `puppetlabs-docker`, which sets `--provision-prefer provision_service --provision-exclude docker` because the Docker daemon cannot be exercised inside the litmus container provisioner. Every other module tests 20.04 in `litmusimage/ubuntu:20.04` via the docker provisioner and never reaches this path.

Ubuntu-20.04 has been red on every `puppetlabs-docker` nightly where Acceptance ran, across all 206 retained workflow runs — so this is a long-standing breakage, not a regression.

## Reviewer notes

**Cost.** Ubuntu Pro images carry a GCP per-hour license surcharge that standard `ubuntu-os-cloud` images do not. Worth a conscious decision given CI provisions VMs continuously. If that is unacceptable, the alternative is dropping 20.04 rather than a cheaper image — no non-Pro focal family exists any more.

**Verification.** `exe/matrix.json` parses as valid JSON and the Ubuntu block is otherwise untouched. The `ubuntu-2004` hits in `spec/lib/puppet_litmus/rake_helper_spec.rb` are ABS platform strings (`ubuntu-2004-x86_64`), unrelated to GCP image families, so no spec changes are needed. I have not been able to run an end-to-end provision against the Pro family — that needs a real CI run.

## Not fixed here

- **CentOS 8** — `centos-stream-8` returns no images in any public project. Stream 8 hit EOL 2024-05-31 and Google removed it, with no Pro-style continuation. Needs a separate decision: drop it, repoint at `rocky-linux-cloud/rocky-linux-8` / `almalinux-cloud/almalinux-8`, or build a custom image.
- **CentOS 7** — `centos-7` in this same file may be dead for the same reason; unverified.
- **Debian 10** — provisions fine, then fails at `litmus:install_agent` because the `debian-10-buster-v20200309-eol` image has archived apt sources and the repair block in provision_service's `debian.sh.erb` is unreachable under `set -e`. Addressed in puppetlabs/provision_service#439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
